### PR TITLE
Handle scheduler invoker return-type drift

### DIFF
--- a/supabase/migrations/20260722010000_harden_queue_scheduler.sql
+++ b/supabase/migrations/20260722010000_harden_queue_scheduler.sql
@@ -272,7 +272,12 @@ $$;
 -- pg_net is asynchronous: http_post returns a request id, not a synchronous
 -- response record. Returning the id accurately reports that invocation was
 -- queued without pretending an HTTP response has already arrived.
-CREATE OR REPLACE FUNCTION public.invoke_edge_function_v2(
+-- PostgreSQL cannot change a function return type with CREATE OR REPLACE.
+-- Drop the exact signature first so this migration also reconciles databases
+-- where the function's return type drifted from the migration history.
+DROP FUNCTION IF EXISTS public.invoke_edge_function_v2(text, jsonb, integer);
+
+CREATE FUNCTION public.invoke_edge_function_v2(
   p_function_name text,
   p_payload jsonb DEFAULT '{}'::jsonb,
   p_timeout_milliseconds integer DEFAULT 300000

--- a/supabase/tests/backend_ranking_verification.sql
+++ b/supabase/tests/backend_ranking_verification.sql
@@ -226,6 +226,12 @@ BEGIN
      ) > 0 THEN
     RAISE EXCEPTION 'Asynchronous pg_net invoker still treats request id as a response';
   END IF;
+
+  IF pg_get_function_result(
+       'public.invoke_edge_function_v2(text,jsonb,integer)'::regprocedure
+     ) <> 'jsonb' THEN
+    RAISE EXCEPTION 'Asynchronous pg_net invoker must return jsonb';
+  END IF;
 END;
 $$;
 


### PR DESCRIPTION
### Summary
Fixes the production scheduler migration failure caused by invoke_edge_function_v2(text, jsonb, integer) returning bigint in production instead of the expected jsonb.
The migration now:

- Drops the exact existing function signature before recreating it.
- Restores the intended asynchronous jsonb response containing the pg_net request ID.
- Adds a regression assertion for the function’s return type.

### Verification

- PostgreSQL 15 production-drift simulation passed.
- No dependent database objects were found.
- 8 browser tests passed.
- Production build passed.
- Makes no FMP API calls.