### PR TITLE
Fix negative-cache freshness tracking

### DIFF
--- a/supabase/functions/__tests__/record-data-fetch-freshness.test.ts
+++ b/supabase/functions/__tests__/record-data-fetch-freshness.test.ts
@@ -1,0 +1,60 @@
+import {
+  assertEquals,
+  assertRejects,
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { recordDataFetchFreshness } from "../lib/record-data-fetch-freshness.ts";
+import type { QueueJob } from "../lib/types.ts";
+
+const job: QueueJob = {
+  id: "job-1",
+  symbol: "AAPL",
+  data_type: "insider-transactions",
+  status: "processing",
+  priority: 1,
+  retry_count: 0,
+  max_retries: 3,
+  created_at: "2026-07-30T00:00:00Z",
+  estimated_data_size_bytes: 200000,
+  job_metadata: {},
+};
+
+Deno.test("records a successful empty fetch with its measured response size", async () => {
+  let rpcName = "";
+  let rpcArguments: Record<string, unknown> = {};
+  const supabase = {
+    rpc: (
+      name: string,
+      args: Record<string, unknown>,
+    ) => {
+      rpcName = name;
+      rpcArguments = args;
+      return Promise.resolve({ error: null });
+    },
+  } as unknown as SupabaseClient;
+
+  await recordDataFetchFreshness(supabase, job, false, 1234);
+
+  assertEquals(rpcName, "record_data_fetch_freshness_v2");
+  assertEquals(rpcArguments, {
+    p_symbol: "AAPL",
+    p_data_type: "insider-transactions",
+    p_has_data: false,
+    p_response_size_bytes: 1234,
+  });
+});
+
+Deno.test("fails the queue handler when freshness cannot be persisted", async () => {
+  const supabase = {
+    rpc: () =>
+      Promise.resolve({
+        error: { message: "database unavailable" },
+      }),
+  } as unknown as SupabaseClient;
+
+  await assertRejects(
+    () => recordDataFetchFreshness(supabase, job, false, 1234),
+    Error,
+    "Failed to record fetch freshness",
+  );
+});

--- a/supabase/functions/lib/fetch-fmp-insider-trading-statistics.ts
+++ b/supabase/functions/lib/fetch-fmp-insider-trading-statistics.ts
@@ -5,6 +5,7 @@
 import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { QueueJob, ProcessJobResult } from './types.ts';
+import { recordDataFetchFreshness } from './record-data-fetch-freshness.ts';
 
 const FMP_API_KEY = Deno.env.get('FMP_API_KEY');
 const FMP_INSIDER_TRADING_STATISTICS_BASE_URL = 'https://financialmodelingprep.com/stable/insider-trading/statistics';
@@ -85,20 +86,8 @@ export async function fetchInsiderTradingStatisticsLogic(
         Object.keys(fmpResult).length === 0
       ) {
         // No insider trading data found - this is a valid response
-        // CRITICAL: Update fetched_at for existing records to prevent infinite job creation
-        const { error: updateError } = await supabase
-          .from('insider_trading_statistics')
-          .update({ fetched_at: new Date().toISOString() })
-          .eq('symbol', job.symbol);
-
-        if (updateError) {
-          console.warn(
-            `[fetchInsiderTradingStatisticsLogic] Failed to update fetched_at for ${job.symbol}:`,
-            updateError.message
-          );
-        }
-
-        console.log(`[fetchInsiderTradingStatisticsLogic] No insider trading data found for ${job.symbol} (empty object returned by FMP). Updated fetched_at to prevent infinite job creation.`);
+        await recordDataFetchFreshness(supabase, job, false, actualSizeBytes);
+        console.log(`[fetchInsiderTradingStatisticsLogic] No insider trading data found for ${job.symbol} (empty object returned by FMP). Recorded successful empty freshness.`);
         return {
           success: true,
           dataSizeBytes: actualSizeBytes,
@@ -109,20 +98,8 @@ export async function fetchInsiderTradingStatisticsLogic(
 
     if (fmpResult.length === 0) {
       // Empty array - no insider trading data found
-      // CRITICAL: Update fetched_at for existing records to prevent infinite job creation
-      const { error: updateError } = await supabase
-        .from('insider_trading_statistics')
-        .update({ fetched_at: new Date().toISOString() })
-        .eq('symbol', job.symbol);
-
-      if (updateError) {
-        console.warn(
-          `[fetchInsiderTradingStatisticsLogic] Failed to update fetched_at for ${job.symbol}:`,
-          updateError.message
-        );
-      }
-
-      console.log(`[fetchInsiderTradingStatisticsLogic] No insider trading data found for ${job.symbol} (empty array returned by FMP). Updated fetched_at to prevent infinite job creation.`);
+      await recordDataFetchFreshness(supabase, job, false, actualSizeBytes);
+      console.log(`[fetchInsiderTradingStatisticsLogic] No insider trading data found for ${job.symbol} (empty array returned by FMP). Recorded successful empty freshness.`);
       return {
         success: true,
         dataSizeBytes: actualSizeBytes,
@@ -176,6 +153,7 @@ export async function fetchInsiderTradingStatisticsLogic(
       throw new Error(`Failed to upsert insider trading statistics for ${job.symbol}: ${upsertError.message}`);
     }
 
+    await recordDataFetchFreshness(supabase, job, dbRecords.length > 0, actualSizeBytes);
 
     return {
       success: true,
@@ -191,4 +169,3 @@ export async function fetchInsiderTradingStatisticsLogic(
     };
   }
 }
-

--- a/supabase/functions/lib/fetch-fmp-insider-transactions.ts
+++ b/supabase/functions/lib/fetch-fmp-insider-transactions.ts
@@ -6,6 +6,7 @@
 import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { QueueJob, ProcessJobResult } from './types.ts';
+import { recordDataFetchFreshness } from './record-data-fetch-freshness.ts';
 
 const FMP_API_KEY = Deno.env.get('FMP_API_KEY');
 const FMP_INSIDER_TRANSACTIONS_BASE_URL = 'https://financialmodelingprep.com/stable/insider-trading/search';
@@ -96,20 +97,8 @@ export async function fetchInsiderTransactionsLogic(
         Object.keys(fmpResult).length === 0
       ) {
         // No insider transaction data found - this is a valid response
-        // CRITICAL: Update fetched_at for existing records to prevent infinite job creation
-        const { error: updateError } = await supabase
-          .from('insider_transactions')
-          .update({ fetched_at: new Date().toISOString() })
-          .eq('symbol', job.symbol);
-
-        if (updateError) {
-          console.warn(
-            `[fetchInsiderTransactionsLogic] Failed to update fetched_at for ${job.symbol}:`,
-            updateError.message
-          );
-        }
-
-        console.log(`[fetchInsiderTransactionsLogic] No insider transaction data found for ${job.symbol} (empty object returned by FMP). Updated fetched_at to prevent infinite job creation.`);
+        await recordDataFetchFreshness(supabase, job, false, actualSizeBytes);
+        console.log(`[fetchInsiderTransactionsLogic] No insider transaction data found for ${job.symbol} (empty object returned by FMP). Recorded successful empty freshness.`);
         return {
           success: true,
           dataSizeBytes: actualSizeBytes,
@@ -120,20 +109,8 @@ export async function fetchInsiderTransactionsLogic(
 
     if (fmpResult.length === 0) {
       // Empty array - no insider transaction data found
-      // CRITICAL: Update fetched_at for existing records to prevent infinite job creation
-      const { error: updateError } = await supabase
-        .from('insider_transactions')
-        .update({ fetched_at: new Date().toISOString() })
-        .eq('symbol', job.symbol);
-
-      if (updateError) {
-        console.warn(
-          `[fetchInsiderTransactionsLogic] Failed to update fetched_at for ${job.symbol}:`,
-          updateError.message
-        );
-      }
-
-      console.log(`[fetchInsiderTransactionsLogic] No insider transaction data found for ${job.symbol} (empty array returned by FMP). Updated fetched_at to prevent infinite job creation.`);
+      await recordDataFetchFreshness(supabase, job, false, actualSizeBytes);
+      console.log(`[fetchInsiderTransactionsLogic] No insider transaction data found for ${job.symbol} (empty array returned by FMP). Recorded successful empty freshness.`);
       return {
         success: true,
         dataSizeBytes: actualSizeBytes,
@@ -221,6 +198,12 @@ export async function fetchInsiderTransactionsLogic(
       throw new Error(`Failed to upsert insider transactions for ${job.symbol}: ${upsertError.message}`);
     }
 
+    await recordDataFetchFreshness(
+      supabase,
+      job,
+      deduplicatedRecords.length > 0,
+      actualSizeBytes
+    );
 
     return {
       success: true,
@@ -236,4 +219,3 @@ export async function fetchInsiderTransactionsLogic(
     };
   }
 }
-

--- a/supabase/functions/lib/record-data-fetch-freshness.ts
+++ b/supabase/functions/lib/record-data-fetch-freshness.ts
@@ -1,0 +1,27 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { QueueJob } from "./types.ts";
+
+/**
+ * Record freshness only after an upstream response has been validated and any
+ * returned business data has been persisted. A failure here fails the queue
+ * job so a successful empty response can never be silently left uncached.
+ */
+export async function recordDataFetchFreshness(
+  supabase: SupabaseClient,
+  job: QueueJob,
+  hasData: boolean,
+  responseSizeBytes: number,
+): Promise<void> {
+  const { error } = await supabase.rpc("record_data_fetch_freshness_v2", {
+    p_symbol: job.symbol,
+    p_data_type: job.data_type,
+    p_has_data: hasData,
+    p_response_size_bytes: responseSizeBytes,
+  });
+
+  if (error) {
+    throw new Error(
+      `Failed to record fetch freshness for ${job.symbol}/${job.data_type}: ${error.message}`,
+    );
+  }
+}

--- a/supabase/migrations/20260730000000_add_data_fetch_freshness_v2.sql
+++ b/supabase/migrations/20260730000000_add_data_fetch_freshness_v2.sql
@@ -1,0 +1,415 @@
+-- Record successful fetches independently from data rows so an empty API
+-- response can be cached without inventing sentinel business data.
+
+CREATE TABLE public.data_fetch_freshness_v2 (
+  symbol TEXT NOT NULL,
+  data_type TEXT NOT NULL
+    REFERENCES public.data_type_registry_v2(data_type)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE,
+  last_success_at TIMESTAMPTZ NOT NULL,
+  result_kind TEXT NOT NULL
+    CHECK (result_kind IN ('data', 'empty')),
+  response_size_bytes BIGINT NOT NULL DEFAULT 0
+    CHECK (response_size_bytes >= 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (symbol, data_type),
+  CHECK (symbol = UPPER(BTRIM(symbol)) AND symbol <> '')
+);
+
+COMMENT ON TABLE public.data_fetch_freshness_v2 IS
+  'Last successful upstream fetch by symbol and data type, including valid empty responses. Failed fetches must never write this table.';
+COMMENT ON COLUMN public.data_fetch_freshness_v2.result_kind IS
+  'data when the successful response produced persisted records; empty when the upstream response was valid but contained no records.';
+
+CREATE INDEX idx_data_fetch_freshness_v2_data_type_success
+  ON public.data_fetch_freshness_v2(data_type, last_success_at);
+
+ALTER TABLE public.data_fetch_freshness_v2 ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.data_fetch_freshness_v2 FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON public.data_fetch_freshness_v2 FROM service_role;
+GRANT SELECT ON public.data_fetch_freshness_v2 TO service_role;
+
+CREATE OR REPLACE FUNCTION public.record_data_fetch_freshness_v2(
+  p_symbol TEXT,
+  p_data_type TEXT,
+  p_has_data BOOLEAN,
+  p_response_size_bytes BIGINT DEFAULT 0
+)
+RETURNS TIMESTAMPTZ
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, extensions
+AS $$
+DECLARE
+  v_symbol TEXT := UPPER(BTRIM(p_symbol));
+  v_recorded_at TIMESTAMPTZ := clock_timestamp();
+BEGIN
+  IF v_symbol IS NULL OR v_symbol = '' THEN
+    RAISE EXCEPTION 'symbol must not be empty';
+  END IF;
+
+  IF p_data_type IS NULL OR NOT EXISTS (
+    SELECT 1
+    FROM public.data_type_registry_v2 registry
+    WHERE registry.data_type = p_data_type
+  ) THEN
+    RAISE EXCEPTION 'unknown data type: %', p_data_type;
+  END IF;
+
+  IF p_has_data IS NULL THEN
+    RAISE EXCEPTION 'p_has_data must not be null';
+  END IF;
+
+  IF p_response_size_bytes IS NULL OR p_response_size_bytes < 0 THEN
+    RAISE EXCEPTION 'response size must be non-negative';
+  END IF;
+
+  INSERT INTO public.data_fetch_freshness_v2 (
+    symbol,
+    data_type,
+    last_success_at,
+    result_kind,
+    response_size_bytes,
+    updated_at
+  )
+  VALUES (
+    v_symbol,
+    p_data_type,
+    v_recorded_at,
+    CASE WHEN p_has_data THEN 'data' ELSE 'empty' END,
+    p_response_size_bytes,
+    v_recorded_at
+  )
+  ON CONFLICT (symbol, data_type) DO UPDATE
+  SET
+    last_success_at = EXCLUDED.last_success_at,
+    result_kind = EXCLUDED.result_kind,
+    response_size_bytes = EXCLUDED.response_size_bytes,
+    updated_at = EXCLUDED.updated_at;
+
+  RETURN v_recorded_at;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_data_fetch_freshness_v2(TEXT, TEXT, BOOLEAN, BIGINT)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.record_data_fetch_freshness_v2(TEXT, TEXT, BOOLEAN, BIGINT)
+  TO service_role;
+
+COMMENT ON FUNCTION public.record_data_fetch_freshness_v2(TEXT, TEXT, BOOLEAN, BIGINT) IS
+  'Records a successful upstream fetch. Call only after a response is validated and any returned data is persisted; never call for transport, validation, or database failures.';
+
+CREATE OR REPLACE FUNCTION public.effective_data_fetch_timestamp_v2(
+  p_symbol TEXT,
+  p_data_type TEXT,
+  p_data_fetched_at TIMESTAMPTZ
+)
+RETURNS TIMESTAMPTZ
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public, extensions
+AS $$
+  SELECT CASE
+    WHEN p_data_fetched_at IS NULL THEN freshness.last_success_at
+    WHEN freshness.last_success_at IS NULL THEN p_data_fetched_at
+    ELSE GREATEST(p_data_fetched_at, freshness.last_success_at)
+  END
+  FROM (
+    SELECT (
+      SELECT stored.last_success_at
+      FROM public.data_fetch_freshness_v2 stored
+      WHERE stored.symbol = UPPER(BTRIM(p_symbol))
+        AND stored.data_type = p_data_type
+    ) AS last_success_at
+  ) freshness;
+$$;
+
+REVOKE ALL ON FUNCTION public.effective_data_fetch_timestamp_v2(TEXT, TEXT, TIMESTAMPTZ)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.effective_data_fetch_timestamp_v2(TEXT, TEXT, TIMESTAMPTZ)
+  TO service_role;
+
+COMMENT ON FUNCTION public.effective_data_fetch_timestamp_v2(TEXT, TEXT, TIMESTAMPTZ) IS
+  'Returns the newest successful fetch timestamp from either persisted data or the explicit freshness record.';
+
+-- Event-driven and scheduled checks both pass through this function. Use one
+-- aggregate timestamp for every data type so multi-row tables do not become
+-- stale merely because they contain older historical rows.
+CREATE OR REPLACE FUNCTION public.check_and_queue_stale_batch_v2(
+  p_symbol TEXT,
+  p_data_types TEXT[],
+  p_priority INTEGER
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  reg_row RECORD;
+  is_stale BOOLEAN;
+  is_super_stale BOOLEAN;
+  sql_text TEXT;
+  exchange_is_open BOOLEAN;
+  data_exists BOOLEAN;
+  source_fetched_at TIMESTAMPTZ;
+  effective_fetched_at TIMESTAMPTZ;
+BEGIN
+  FOR reg_row IN
+    SELECT *
+    FROM public.data_type_registry_v2
+    WHERE data_type = ANY(p_data_types)
+  LOOP
+    IF NOT public.is_valid_identifier(reg_row.table_name)
+       OR NOT public.is_valid_identifier(reg_row.symbol_column)
+       OR NOT public.is_valid_identifier(reg_row.timestamp_column)
+       OR NOT public.is_valid_identifier(reg_row.staleness_function)
+    THEN
+      RAISE EXCEPTION 'Invalid identifier found in data_type_registry_v2: %',
+        reg_row.data_type;
+    END IF;
+
+    BEGIN
+      sql_text := format(
+        'SELECT COUNT(*) > 0, MAX(t.%I) FROM %I t WHERE t.%I = %L',
+        reg_row.timestamp_column,
+        reg_row.table_name,
+        reg_row.symbol_column,
+        p_symbol
+      );
+      EXECUTE sql_text INTO data_exists, source_fetched_at;
+
+      IF reg_row.data_type = 'quote' AND data_exists THEN
+        SELECT public.is_exchange_open_for_symbol_v2(p_symbol, 'quote')
+        INTO exchange_is_open;
+
+        IF NOT exchange_is_open THEN
+          sql_text := format(
+            'SELECT %I($1, 1440)',
+            reg_row.staleness_function
+          );
+          EXECUTE sql_text USING source_fetched_at INTO is_super_stale;
+
+          IF NOT COALESCE(is_super_stale, TRUE) THEN
+            CONTINUE;
+          END IF;
+        END IF;
+      END IF;
+
+      effective_fetched_at :=
+        public.effective_data_fetch_timestamp_v2(
+          p_symbol,
+          reg_row.data_type,
+          source_fetched_at
+        );
+
+      sql_text := format(
+        'SELECT %I($1, $2)',
+        reg_row.staleness_function
+      );
+      EXECUTE sql_text
+        USING effective_fetched_at, reg_row.default_ttl_minutes
+        INTO is_stale;
+
+      IF COALESCE(is_stale, TRUE) THEN
+        PERFORM public.queue_refresh_if_not_exists_v2(
+          p_symbol,
+          reg_row.data_type,
+          p_priority,
+          reg_row.estimated_data_size_bytes
+        );
+      END IF;
+    EXCEPTION
+      WHEN OTHERS THEN
+        RAISE WARNING
+          'Staleness check failed for symbol % and type %: %. Assuming stale.',
+          p_symbol,
+          reg_row.data_type,
+          SQLERRM;
+        PERFORM public.queue_refresh_if_not_exists_v2(
+          p_symbol,
+          reg_row.data_type,
+          p_priority,
+          reg_row.estimated_data_size_bytes
+        );
+    END;
+  END LOOP;
+END;
+$$;
+
+COMMENT ON FUNCTION public.check_and_queue_stale_batch_v2(TEXT, TEXT[], INTEGER) IS
+  'Queues stale data using the newest persisted or explicitly recorded successful fetch. Valid empty responses remain fresh for the registry TTL. Failed checks fail safe to stale. Quote refreshes retain the closed-market 24-hour super-stale bypass.';
+
+-- Presence-driven refreshes must consult the same effective timestamp. Keeping
+-- this decision in PL/pgSQL also avoids a multi-row LEFT JOIN where one old
+-- historical insider row could make an otherwise fresh symbol look stale.
+CREATE OR REPLACE FUNCTION public.check_and_queue_stale_data_from_presence_v2()
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = public, extensions
+AS $$
+DECLARE
+  reg_row RECORD;
+  symbol_row RECORD;
+  sql_text TEXT;
+  lock_acquired BOOLEAN;
+  start_time TIMESTAMPTZ := clock_timestamp();
+  max_duration_seconds INTEGER := 50;
+  symbols_processed INTEGER := 0;
+  max_symbols_per_run INTEGER := 1000;
+  exchange_is_open BOOLEAN;
+  data_exists BOOLEAN;
+  source_fetched_at TIMESTAMPTZ;
+  effective_fetched_at TIMESTAMPTZ;
+  is_stale BOOLEAN;
+  is_super_stale BOOLEAN;
+  user_count INTEGER;
+  queue_priority INTEGER;
+BEGIN
+  SELECT pg_try_advisory_lock(42) INTO lock_acquired;
+  IF NOT lock_acquired THEN
+    RETURN;
+  END IF;
+
+  BEGIN
+    IF public.is_quota_exceeded_v2() THEN
+      PERFORM pg_advisory_unlock(42);
+      RETURN;
+    END IF;
+
+    FOR symbol_row IN
+      SELECT DISTINCT symbol
+      FROM public.get_active_subscriptions_from_realtime()
+      WHERE symbol IS NOT NULL
+      LIMIT max_symbols_per_run
+    LOOP
+      IF EXTRACT(EPOCH FROM (clock_timestamp() - start_time))
+         > max_duration_seconds
+      THEN
+        PERFORM pg_advisory_unlock(42);
+        RETURN;
+      END IF;
+
+      symbols_processed := symbols_processed + 1;
+
+      FOR reg_row IN
+        SELECT DISTINCT registry.*
+        FROM public.data_type_registry_v2 registry
+        INNER JOIN public.get_active_subscriptions_from_realtime() subscription
+          ON subscription.symbol = symbol_row.symbol
+         AND subscription.data_type = registry.data_type
+        WHERE registry.refresh_strategy = 'on-demand'
+      LOOP
+        IF EXTRACT(EPOCH FROM (clock_timestamp() - start_time))
+           > max_duration_seconds
+        THEN
+          PERFORM pg_advisory_unlock(42);
+          RETURN;
+        END IF;
+
+        IF NOT public.is_valid_identifier(reg_row.table_name)
+           OR NOT public.is_valid_identifier(reg_row.symbol_column)
+           OR NOT public.is_valid_identifier(reg_row.timestamp_column)
+           OR NOT public.is_valid_identifier(reg_row.staleness_function)
+        THEN
+          CONTINUE;
+        END IF;
+
+        BEGIN
+          sql_text := format(
+            'SELECT COUNT(*) > 0, MAX(t.%I) FROM %I t WHERE t.%I = %L',
+            reg_row.timestamp_column,
+            reg_row.table_name,
+            reg_row.symbol_column,
+            symbol_row.symbol
+          );
+          EXECUTE sql_text INTO data_exists, source_fetched_at;
+
+          IF reg_row.data_type = 'quote' AND data_exists THEN
+            SELECT public.is_exchange_open_for_symbol_v2(
+              symbol_row.symbol,
+              'quote'
+            )
+            INTO exchange_is_open;
+
+            IF NOT exchange_is_open THEN
+              sql_text := format(
+                'SELECT %I($1, 1440)',
+                reg_row.staleness_function
+              );
+              EXECUTE sql_text USING source_fetched_at INTO is_super_stale;
+
+              IF NOT COALESCE(is_super_stale, TRUE) THEN
+                CONTINUE;
+              END IF;
+            END IF;
+          END IF;
+
+          effective_fetched_at :=
+            public.effective_data_fetch_timestamp_v2(
+              symbol_row.symbol,
+              reg_row.data_type,
+              source_fetched_at
+            );
+
+          sql_text := format(
+            'SELECT %I($1, $2)',
+            reg_row.staleness_function
+          );
+          EXECUTE sql_text
+            USING effective_fetched_at, reg_row.default_ttl_minutes
+            INTO is_stale;
+
+          IF COALESCE(is_stale, TRUE) THEN
+            SELECT COUNT(DISTINCT subscription.user_id)::INTEGER
+            INTO user_count
+            FROM public.get_active_subscriptions_from_realtime() subscription
+            WHERE subscription.symbol = symbol_row.symbol
+              AND subscription.data_type = reg_row.data_type;
+
+            queue_priority := CASE
+              WHEN reg_row.data_type = 'financial-statements'
+                   AND user_count < 1000
+                THEN 500
+              ELSE GREATEST(user_count, 1)
+            END;
+
+            PERFORM public.queue_refresh_if_not_exists_v2(
+              symbol_row.symbol,
+              reg_row.data_type,
+              queue_priority,
+              reg_row.estimated_data_size_bytes
+            );
+          END IF;
+        EXCEPTION
+          WHEN OTHERS THEN
+            RAISE WARNING
+              'Presence staleness check failed for symbol % and type %: %',
+              symbol_row.symbol,
+              reg_row.data_type,
+              SQLERRM;
+            CONTINUE;
+        END;
+      END LOOP;
+    END LOOP;
+
+    INSERT INTO public.cron_health_logs (jobname, last_run)
+    VALUES ('check-stale-data-v2', NOW())
+    ON CONFLICT (jobname) DO UPDATE
+    SET last_run = EXCLUDED.last_run;
+
+    PERFORM pg_advisory_unlock(42);
+  EXCEPTION
+    WHEN OTHERS THEN
+      PERFORM pg_advisory_unlock(42);
+      RAISE;
+  END;
+END;
+$$;
+
+COMMENT ON FUNCTION public.check_and_queue_stale_data_from_presence_v2() IS
+  'Presence-driven staleness checker. Uses explicit successful-fetch freshness for valid empty responses, aggregates multi-row data timestamps, preserves quota/lock/timeout controls, and retains the quote closed-market super-stale bypass.';

--- a/tests/contracts/run_all_contracts.sql
+++ b/tests/contracts/run_all_contracts.sql
@@ -73,5 +73,8 @@ END $$;
 \i test_contract_18_security_definer.sql
 
 \echo ''
-\echo '✅ All contract tests completed!'
+\echo 'Running Contract #19: Successful Empty Fetch Freshness...'
+\i test_contract_19_negative_cache_freshness.sql
 
+\echo ''
+\echo '✅ All contract tests completed!'

--- a/tests/contracts/test_contract_19_negative_cache_freshness.sql
+++ b/tests/contracts/test_contract_19_negative_cache_freshness.sql
@@ -1,0 +1,223 @@
+-- Contract #19: Successful Empty Fetch Freshness
+-- Valid empty upstream responses must remain fresh for the registry TTL without
+-- inserting sentinel business data. Failed writes must not advance freshness.
+
+BEGIN;
+SELECT plan(14);
+
+DELETE FROM public.api_call_queue_v2
+WHERE symbol = 'NEGATIVE_CACHE_TEST'
+  AND data_type = 'insider-transactions';
+
+DELETE FROM public.data_fetch_freshness_v2
+WHERE symbol = 'NEGATIVE_CACHE_TEST'
+  AND data_type = 'insider-transactions';
+
+SELECT has_table(
+  'public',
+  'data_fetch_freshness_v2',
+  'Contract #19: explicit fetch freshness table exists'
+);
+
+SELECT ok(
+  (
+    SELECT relrowsecurity
+    FROM pg_class
+    WHERE oid = 'public.data_fetch_freshness_v2'::regclass
+  ),
+  'Contract #19: freshness table has RLS enabled'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc procedure
+    JOIN pg_namespace namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname = 'public'
+      AND procedure.proname = 'record_data_fetch_freshness_v2'
+      AND procedure.prosecdef
+  ),
+  'Contract #19: freshness recorder is SECURITY DEFINER'
+);
+
+SELECT ok(
+  NOT has_function_privilege(
+    'anon',
+    'public.record_data_fetch_freshness_v2(text,text,boolean,bigint)',
+    'EXECUTE'
+  )
+  AND NOT has_function_privilege(
+    'authenticated',
+    'public.record_data_fetch_freshness_v2(text,text,boolean,bigint)',
+    'EXECUTE'
+  )
+  AND has_function_privilege(
+    'service_role',
+    'public.record_data_fetch_freshness_v2(text,text,boolean,bigint)',
+    'EXECUTE'
+  ),
+  'Contract #19: only the service role can call the freshness recorder'
+);
+
+SELECT ok(
+  has_table_privilege(
+    'service_role',
+    'public.data_fetch_freshness_v2',
+    'SELECT'
+  )
+  AND NOT has_table_privilege(
+    'service_role',
+    'public.data_fetch_freshness_v2',
+    'INSERT'
+  )
+  AND NOT has_table_privilege(
+    'service_role',
+    'public.data_fetch_freshness_v2',
+    'UPDATE'
+  ),
+  'Contract #19: service code reads the ledger but writes only through the validated recorder'
+);
+
+SELECT lives_ok(
+  $$
+    SELECT public.record_data_fetch_freshness_v2(
+      'negative_cache_test',
+      'insider-transactions',
+      FALSE,
+      1234
+    )
+  $$,
+  'Contract #19: a successful empty response can be recorded'
+);
+
+SELECT is(
+  (
+    SELECT result_kind
+    FROM public.data_fetch_freshness_v2
+    WHERE symbol = 'NEGATIVE_CACHE_TEST'
+      AND data_type = 'insider-transactions'
+  ),
+  'empty',
+  'Contract #19: empty responses are distinguished from data responses'
+);
+
+SELECT is(
+  public.effective_data_fetch_timestamp_v2(
+    'NEGATIVE_CACHE_TEST',
+    'insider-transactions',
+    NULL
+  ),
+  (
+    SELECT last_success_at
+    FROM public.data_fetch_freshness_v2
+    WHERE symbol = 'NEGATIVE_CACHE_TEST'
+      AND data_type = 'insider-transactions'
+  ),
+  'Contract #19: explicit success supplies freshness when no data row exists'
+);
+
+SELECT lives_ok(
+  $$
+    SELECT public.check_and_queue_stale_batch_v2(
+      'NEGATIVE_CACHE_TEST',
+      ARRAY['insider-transactions'],
+      1
+    )
+  $$,
+  'Contract #19: staleness checks accept successful empty freshness'
+);
+
+SELECT is(
+  (
+    SELECT COUNT(*)::INTEGER
+    FROM public.api_call_queue_v2
+    WHERE symbol = 'NEGATIVE_CACHE_TEST'
+      AND data_type = 'insider-transactions'
+      AND status IN ('pending', 'processing')
+  ),
+  0,
+  'Contract #19: a fresh empty response is not immediately requeued'
+);
+
+CREATE TEMP TABLE negative_cache_timestamp_before_failure AS
+SELECT last_success_at
+FROM public.data_fetch_freshness_v2
+WHERE symbol = 'NEGATIVE_CACHE_TEST'
+  AND data_type = 'insider-transactions';
+
+DO $$
+BEGIN
+  BEGIN
+    PERFORM public.record_data_fetch_freshness_v2(
+      'NEGATIVE_CACHE_TEST',
+      'insider-transactions',
+      FALSE,
+      -1
+    );
+    RAISE EXCEPTION 'negative response size should have failed';
+  EXCEPTION
+    WHEN OTHERS THEN
+      NULL;
+  END;
+END;
+$$;
+
+SELECT is(
+  (
+    SELECT last_success_at
+    FROM public.data_fetch_freshness_v2
+    WHERE symbol = 'NEGATIVE_CACHE_TEST'
+      AND data_type = 'insider-transactions'
+  ),
+  (
+    SELECT last_success_at
+    FROM negative_cache_timestamp_before_failure
+  ),
+  'Contract #19: a failed record attempt does not advance freshness'
+);
+
+UPDATE public.data_fetch_freshness_v2
+SET last_success_at = NOW() - INTERVAL '3 days'
+WHERE symbol = 'NEGATIVE_CACHE_TEST'
+  AND data_type = 'insider-transactions';
+
+SELECT lives_ok(
+  $$
+    SELECT public.check_and_queue_stale_batch_v2(
+      'NEGATIVE_CACHE_TEST',
+      ARRAY['insider-transactions'],
+      1
+    )
+  $$,
+  'Contract #19: an expired empty response can be checked normally'
+);
+
+SELECT is(
+  (
+    SELECT COUNT(*)::INTEGER
+    FROM public.api_call_queue_v2
+    WHERE symbol = 'NEGATIVE_CACHE_TEST'
+      AND data_type = 'insider-transactions'
+      AND status = 'pending'
+  ),
+  1,
+  'Contract #19: an expired empty response becomes refreshable again'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc procedure
+    JOIN pg_namespace namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname = 'public'
+      AND procedure.proname = 'check_and_queue_stale_data_from_presence_v2'
+      AND pg_get_functiondef(procedure.oid)
+        ~* 'effective_data_fetch_timestamp_v2'
+  ),
+  'Contract #19: presence-driven refreshes consume explicit successful-fetch freshness'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

- add a service-only per-symbol/data-type freshness ledger for successful data and empty responses
- record insider transaction and insider statistics freshness only after validation and persistence succeed
- make scheduled and presence-driven staleness checks honor valid empty responses for the configured TTL
- aggregate multi-row timestamps so old historical rows do not force repeated refreshes

## Safety

- failed fetches never advance freshness
- no Compass serving gate, TTL, cron activation, or 20 GiB quota change
- migration must deploy before queue-processor-v2

## Validation

- complete migration chain applied to a disposable PostgreSQL 15 database
- negative-cache contract: 14/14 passed
- Deno unit tests: 2/2 passed
- Deno check and lint passed

Known baseline: legacy Contract #9 still expects TABLESAMPLE although the scheduler now uses round-robin; this PR does not modify that scheduler.