### PR TITLE
Restore scheduled Compass data refreshes

### DIFF
--- a/scripts/operations/activate-scheduled-refresh-baseline.sql
+++ b/scripts/operations/activate-scheduled-refresh-baseline.sql
@@ -1,0 +1,134 @@
+\set ON_ERROR_STOP on
+
+-- MUTATING PRODUCTION OPERATION.
+--
+-- This enables the full-universe scheduler. It does not invoke FMP directly,
+-- but the active processor will begin consuming queued work. Run the read-only
+-- verify-scheduled-refresh-readiness.sql first and require
+-- ready_for_scheduled_activation=true.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_usage record;
+  v_calibrated_at timestamptz;
+  v_active_processor_paths integer;
+  v_active_queue_jobs integer;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM supabase_migrations.schema_migrations AS migration
+    WHERE migration.version = '20260731000000'
+  ) THEN
+    RAISE EXCEPTION
+      'Scheduled refresh migration 20260731000000 is not recorded';
+  END IF;
+
+  SELECT *
+  INTO v_usage
+  FROM public.get_effective_quota_usage_v2();
+
+  SELECT calibration.captured_at
+  INTO v_calibrated_at
+  FROM public.fmp_quota_calibrations AS calibration
+  WHERE calibration.active
+  ORDER BY calibration.id DESC
+  LIMIT 1;
+
+  IF NOT v_usage.is_calibrated
+     OR v_calibrated_at < now() - interval '6 hours' THEN
+    RAISE EXCEPTION
+      'A current (under 6 hours old) FMP dashboard calibration is required';
+  END IF;
+
+  IF v_usage.safety_buffer <> 0.90
+     OR v_usage.max_batch_jobs <> 50 THEN
+    RAISE EXCEPTION
+      'Expected 90%% safety buffer and 50-job batch, found % and %',
+      v_usage.safety_buffer,
+      v_usage.max_batch_jobs;
+  END IF;
+
+  IF public.is_quota_exceeded_v2() THEN
+    RAISE EXCEPTION 'Effective quota usage is already at the safety ceiling';
+  END IF;
+
+  SELECT count(*)
+  INTO v_active_queue_jobs
+  FROM public.api_call_queue_v2 AS queue
+  WHERE queue.status IN ('pending', 'processing');
+
+  IF v_active_queue_jobs <> 0 THEN
+    RAISE EXCEPTION
+      'Queue must be idle before activation; found % active jobs',
+      v_active_queue_jobs;
+  END IF;
+
+  SELECT count(*)
+  INTO v_active_processor_paths
+  FROM public.get_fmp_pipeline_cron_state_v2() AS job
+  WHERE job.active
+    AND (
+      job.jobname = 'invoke-processor-v2'
+      OR job.jobname LIKE 'controlled-fmp-live-processing-%'
+    );
+
+  IF v_active_processor_paths <> 1 THEN
+    RAISE EXCEPTION
+      'Expected exactly one active processor path, found %',
+      v_active_processor_paths;
+  END IF;
+
+  IF (
+    SELECT count(*)
+    FROM public.data_type_registry_v2 AS registry
+    WHERE registry.data_type IN (
+      'profile',
+      'financial-statements',
+      'ratios-ttm',
+      'insider-transactions',
+      'insider-trading-statistics'
+    )
+      AND registry.refresh_strategy = 'hybrid'
+  ) <> 5 THEN
+    RAISE EXCEPTION 'Durable scheduled registry policy is incomplete';
+  END IF;
+
+  IF (
+    SELECT registry.refresh_strategy
+    FROM public.data_type_registry_v2 AS registry
+    WHERE registry.data_type = 'quote'
+  ) <> 'on-demand' THEN
+    RAISE EXCEPTION 'Quote must remain on demand';
+  END IF;
+END;
+$$;
+
+SELECT cron.schedule(
+  'queue-scheduled-refreshes-v2',
+  '* * * * *',
+  'SELECT public.queue_scheduled_refreshes_v2();'
+) AS scheduled_refresh_job_id;
+
+COMMIT;
+
+SELECT jsonb_build_object(
+  'captured_at', now(),
+  'scheduled_refresh_jobs',
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'jobid', job.jobid,
+          'jobname', job.jobname,
+          'schedule', job.schedule,
+          'active', job.active,
+          'command', job.command
+        )
+        ORDER BY job.jobid
+      ),
+      '[]'::jsonb
+    )
+) AS scheduled_refresh_activation
+FROM public.get_fmp_pipeline_cron_state_v2() AS job
+WHERE job.jobname = 'queue-scheduled-refreshes-v2';

--- a/scripts/operations/pause-scheduled-refresh-baseline.sql
+++ b/scripts/operations/pause-scheduled-refresh-baseline.sql
@@ -1,0 +1,39 @@
+\set ON_ERROR_STOP on
+
+-- MUTATING FAIL-SAFE.
+--
+-- Stops new scheduled queue production. Pending/processing work is not
+-- deleted; quota and processor guards remain authoritative.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.get_fmp_pipeline_cron_state_v2() AS job
+    WHERE job.jobname = 'queue-scheduled-refreshes-v2'
+  ) THEN
+    PERFORM cron.unschedule('queue-scheduled-refreshes-v2');
+  END IF;
+END;
+$$;
+
+SELECT jsonb_build_object(
+  'captured_at', now(),
+  'scheduled_refresh_active',
+    EXISTS (
+      SELECT 1
+      FROM public.get_fmp_pipeline_cron_state_v2() AS scheduled
+      WHERE scheduled.jobname = 'queue-scheduled-refreshes-v2'
+        AND scheduled.active
+    ),
+  'queue_statuses',
+    (
+      SELECT jsonb_object_agg(summary.status, summary.jobs)
+      FROM (
+        SELECT queue.status, count(*) AS jobs
+        FROM public.api_call_queue_v2 AS queue
+        WHERE queue.status IN ('pending', 'processing')
+        GROUP BY queue.status
+      ) AS summary
+    )
+) AS scheduled_refresh_pause;

--- a/scripts/operations/verify-scheduled-refresh-readiness.sql
+++ b/scripts/operations/verify-scheduled-refresh-readiness.sql
@@ -1,0 +1,187 @@
+\set ON_ERROR_STOP on
+
+-- READ-ONLY production readiness report.
+--
+-- Run after:
+--   1. migration 20260731000000 is applied;
+--   2. queue-processor-v2 is deployed with the durable empty-response fixes;
+--   3. a current FMP endpoint snapshot is recorded with a 90% safety buffer
+--      and a 50-job maximum batch.
+--
+-- This script does not queue jobs, invoke an Edge Function, alter cron, or call
+-- FMP.
+
+WITH effective AS (
+  SELECT *
+  FROM public.get_effective_quota_usage_v2()
+),
+calibration AS (
+  SELECT
+    snapshot.id,
+    snapshot.captured_at,
+    snapshot.dashboard_headline_usage_gib,
+    snapshot.dashboard_limit_bytes,
+    snapshot.safety_buffer,
+    snapshot.max_batch_jobs
+  FROM public.fmp_quota_calibrations AS snapshot
+  WHERE snapshot.active
+  ORDER BY snapshot.id DESC
+  LIMIT 1
+),
+queue_summary AS (
+  SELECT
+    count(*) FILTER (WHERE queue.status = 'pending') AS pending_jobs,
+    count(*) FILTER (WHERE queue.status = 'processing') AS processing_jobs,
+    count(*) FILTER (
+      WHERE queue.status = 'processing'
+        AND queue.processed_at < now() - interval '5 minutes'
+    ) AS stale_processing_jobs
+  FROM public.api_call_queue_v2 AS queue
+),
+cron_summary AS (
+  SELECT
+    count(*) FILTER (
+      WHERE job.active
+        AND (
+          job.jobname = 'invoke-processor-v2'
+          OR job.jobname LIKE 'controlled-fmp-live-processing-%'
+        )
+    ) AS active_processor_paths,
+    bool_or(
+      job.jobname = 'queue-scheduled-refreshes-v2'
+      AND job.active
+    ) AS scheduled_refresh_active,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'jobid', job.jobid,
+          'jobname', job.jobname,
+          'schedule', job.schedule,
+          'active', job.active
+        )
+        ORDER BY job.jobid
+      ) FILTER (
+        WHERE job.jobname IN (
+          'queue-scheduled-refreshes-v2',
+          'invoke-processor-v2'
+        )
+        OR job.jobname LIKE 'controlled-fmp-live-processing-%'
+      ),
+      '[]'::jsonb
+    ) AS relevant_jobs
+  FROM public.get_fmp_pipeline_cron_state_v2() AS job
+),
+registry AS (
+  SELECT
+    count(*) FILTER (
+      WHERE data_type IN (
+        'profile',
+        'financial-statements',
+        'ratios-ttm',
+        'insider-transactions',
+        'insider-trading-statistics'
+      )
+        AND refresh_strategy = 'hybrid'
+    ) AS hybrid_durable_types,
+    bool_and(refresh_strategy = 'on-demand') FILTER (
+      WHERE data_type = 'quote'
+    ) AS quote_on_demand,
+    jsonb_object_agg(
+      data_type,
+      jsonb_build_object(
+        'strategy', refresh_strategy,
+        'ttl_minutes', default_ttl_minutes
+      )
+      ORDER BY data_type
+    ) FILTER (
+      WHERE data_type IN (
+        'profile',
+        'quote',
+        'financial-statements',
+        'ratios-ttm',
+        'insider-transactions',
+        'insider-trading-statistics'
+      )
+    ) AS policy
+  FROM public.data_type_registry_v2
+),
+facts AS (
+  SELECT
+    EXISTS (
+      SELECT 1
+      FROM supabase_migrations.schema_migrations AS migration
+      WHERE migration.version = '20260731000000'
+    ) AS migration_recorded,
+    effective.*,
+    calibration.id AS current_calibration_id,
+    calibration.captured_at AS current_calibration_at,
+    calibration.dashboard_headline_usage_gib,
+    queue_summary.*,
+    cron_summary.*,
+    registry.*
+  FROM effective
+  LEFT JOIN calibration ON true
+  CROSS JOIN queue_summary
+  CROSS JOIN cron_summary
+  CROSS JOIN registry
+)
+SELECT jsonb_build_object(
+  'captured_at', now(),
+  'ready_for_scheduled_activation',
+    facts.migration_recorded
+    AND facts.is_calibrated
+    AND facts.current_calibration_at >= now() - interval '6 hours'
+    AND facts.safety_buffer = 0.90
+    AND facts.max_batch_jobs = 50
+    AND facts.current_usage_bytes
+        < (facts.quota_limit_bytes * facts.safety_buffer)::bigint
+    AND facts.pending_jobs = 0
+    AND facts.processing_jobs = 0
+    AND facts.stale_processing_jobs = 0
+    AND facts.active_processor_paths = 1
+    AND NOT COALESCE(facts.scheduled_refresh_active, false)
+    AND facts.hybrid_durable_types = 5
+    AND facts.quote_on_demand,
+  'migration_recorded', facts.migration_recorded,
+  'calibration', jsonb_build_object(
+    'id', facts.current_calibration_id,
+    'captured_at', facts.current_calibration_at,
+    'dashboard_headline_usage_gib',
+      facts.dashboard_headline_usage_gib,
+    'limit_gib',
+      round(
+        facts.quota_limit_bytes::numeric
+          / 1024 / 1024 / 1024,
+        2
+      ),
+    'effective_usage_percentage',
+      round(
+        facts.current_usage_bytes::numeric
+          / facts.quota_limit_bytes
+          * 100,
+        4
+      ),
+    'safety_buffer', facts.safety_buffer,
+    'max_batch_jobs', facts.max_batch_jobs,
+    'bytes_to_safety_ceiling',
+      (facts.quota_limit_bytes * facts.safety_buffer)::bigint
+        - facts.current_usage_bytes
+  ),
+  'queue', jsonb_build_object(
+    'pending', facts.pending_jobs,
+    'processing', facts.processing_jobs,
+    'stale_processing', facts.stale_processing_jobs
+  ),
+  'cron', jsonb_build_object(
+    'active_processor_paths', facts.active_processor_paths,
+    'scheduled_refresh_active',
+      COALESCE(facts.scheduled_refresh_active, false),
+    'jobs', facts.relevant_jobs
+  ),
+  'registry', jsonb_build_object(
+    'hybrid_durable_types', facts.hybrid_durable_types,
+    'quote_on_demand', facts.quote_on_demand,
+    'policy', facts.policy
+  )
+) AS scheduled_refresh_readiness
+FROM facts;

--- a/supabase/functions/__tests__/fetch-fmp-durable-empty-freshness.test.ts
+++ b/supabase/functions/__tests__/fetch-fmp-durable-empty-freshness.test.ts
@@ -1,0 +1,206 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { QueueJob } from "../lib/types.ts";
+
+Deno.env.set("FMP_API_KEY", "scheduled-baseline-test-key");
+
+const { fetchProfileLogic } = await import(
+  "../lib/fetch-fmp-profile.ts?durable-empty-test"
+);
+const { fetchRatiosTtmLogic } = await import(
+  "../lib/fetch-fmp-ratios-ttm.ts?durable-empty-test"
+);
+const { fetchFinancialStatementsLogic } = await import(
+  "../lib/fetch-fmp-financial-statements.ts?durable-empty-test"
+);
+
+function queueJob(dataType: string): QueueJob {
+  return {
+    id: `job-${dataType}`,
+    symbol: "EMPTY",
+    data_type: dataType,
+    status: "processing",
+    priority: -1,
+    retry_count: 0,
+    max_retries: 3,
+    created_at: "2026-07-31T00:00:00Z",
+    estimated_data_size_bytes: 1,
+    job_metadata: {},
+  };
+}
+
+function freshnessClient(
+  calls: Array<{ name: string; args: Record<string, unknown> }>,
+): SupabaseClient {
+  return {
+    rpc: (
+      name: string,
+      args: Record<string, unknown>,
+    ) => {
+      calls.push({ name, args });
+      return Promise.resolve({ error: null });
+    },
+    from: (table: string) => {
+      if (table !== "data_type_registry_v2") {
+        throw new Error(`Unexpected table access: ${table}`);
+      }
+
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        single: () =>
+          Promise.resolve({
+            data: { source_timestamp_column: "accepted_date" },
+            error: null,
+          }),
+      };
+      return chain;
+    },
+  } as unknown as SupabaseClient;
+}
+
+Deno.test(
+  "durable FMP handlers record valid empty responses without sentinel writes",
+  async () => {
+    const originalFetch = globalThis.fetch;
+
+    try {
+      {
+        const calls: Array<{
+          name: string;
+          args: Record<string, unknown>;
+        }> = [];
+        globalThis.fetch = () =>
+          Promise.resolve(
+            new Response("[]", {
+              status: 200,
+              headers: { "Content-Length": "17" },
+            }),
+          );
+
+        const result = await fetchProfileLogic(
+          queueJob("profile"),
+          freshnessClient(calls),
+        );
+
+        assertEquals(result.success, true);
+        assertEquals(result.dataSizeBytes, 17);
+        assertEquals(calls, [{
+          name: "record_data_fetch_freshness_v2",
+          args: {
+            p_symbol: "EMPTY",
+            p_data_type: "profile",
+            p_has_data: false,
+            p_response_size_bytes: 17,
+          },
+        }]);
+      }
+
+      {
+        const calls: Array<{
+          name: string;
+          args: Record<string, unknown>;
+        }> = [];
+        globalThis.fetch = () =>
+          Promise.resolve(
+            new Response("[]", {
+              status: 200,
+              headers: { "Content-Length": "23" },
+            }),
+          );
+
+        const result = await fetchRatiosTtmLogic(
+          queueJob("ratios-ttm"),
+          freshnessClient(calls),
+        );
+
+        assertEquals(result.success, true);
+        assertEquals(result.dataSizeBytes, 23);
+        assertEquals(calls, [{
+          name: "record_data_fetch_freshness_v2",
+          args: {
+            p_symbol: "EMPTY",
+            p_data_type: "ratios-ttm",
+            p_has_data: false,
+            p_response_size_bytes: 23,
+          },
+        }]);
+      }
+
+      {
+        const calls: Array<{
+          name: string;
+          args: Record<string, unknown>;
+        }> = [];
+        const responseSizes = [11, 13, 17];
+        globalThis.fetch = () => {
+          const size = responseSizes.shift();
+          if (size === undefined) {
+            throw new Error("Unexpected fourth financial statement request");
+          }
+          return Promise.resolve(
+            new Response("[]", {
+              status: 200,
+              headers: { "Content-Length": String(size) },
+            }),
+          );
+        };
+
+        const result = await fetchFinancialStatementsLogic(
+          queueJob("financial-statements"),
+          freshnessClient(calls),
+        );
+
+        assertEquals(result.success, true);
+        assertEquals(result.dataSizeBytes, 41);
+        assertEquals(responseSizes, []);
+        assertEquals(calls, [{
+          name: "record_data_fetch_freshness_v2",
+          args: {
+            p_symbol: "EMPTY",
+            p_data_type: "financial-statements",
+            p_has_data: false,
+            p_response_size_bytes: 41,
+          },
+        }]);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);
+
+Deno.test(
+  "invalid durable response fails without advancing freshness",
+  async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: Array<{
+      name: string;
+      args: Record<string, unknown>;
+    }> = [];
+
+    try {
+      globalThis.fetch = () =>
+        Promise.resolve(
+          new Response('{"error":"schema drift"}', {
+            status: 200,
+            headers: { "Content-Length": "24" },
+          }),
+        );
+
+      const result = await fetchRatiosTtmLogic(
+        queueJob("ratios-ttm"),
+        freshnessClient(calls),
+      );
+
+      assertEquals(result.success, false);
+      assertStringIncludes(result.error ?? "", "Expected an array");
+      assertEquals(calls, []);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);

--- a/supabase/functions/lib/fetch-fmp-financial-statements.ts
+++ b/supabase/functions/lib/fetch-fmp-financial-statements.ts
@@ -2,32 +2,37 @@
 // Library function for processing financial-statements jobs from the queue
 // CRITICAL: This function is imported directly by queue-processor-v2 (monofunction architecture)
 
-import type { SupabaseClient } from '@supabase/supabase-js';
-import type { QueueJob, ProcessJobResult } from './types.ts';
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ProcessJobResult, QueueJob } from "./types.ts";
 
 // Import types from the original Edge Function
 import type {
-  FmpStatementEntryBase,
-  FmpIncomeStatementEntry,
+  FinancialStatementRecord,
   FmpBalanceSheetEntry,
   FmpCashFlowEntry,
-  FinancialStatementRecord,
-} from '../fetch-fmp-financial-statements/types.ts';
+  FmpIncomeStatementEntry,
+  FmpStatementEntryBase,
+} from "../fetch-fmp-financial-statements/types.ts";
+import { recordDataFetchFreshness } from "./record-data-fetch-freshness.ts";
 
-const FMP_API_KEY = Deno.env.get('FMP_API_KEY');
-const FMP_BASE_URL = 'https://financialmodelingprep.com/stable';
+const FMP_API_KEY = Deno.env.get("FMP_API_KEY");
+const FMP_BASE_URL = "https://financialmodelingprep.com/stable";
 const INCOME_STATEMENT_ENDPOINT = `${FMP_BASE_URL}/income-statement`;
 const BALANCE_SHEET_ENDPOINT = `${FMP_BASE_URL}/balance-sheet-statement`;
 const CASH_FLOW_ENDPOINT = `${FMP_BASE_URL}/cash-flow-statement`;
 const FMP_API_DELAY_MS = 300; // Delay between API calls to respect rate limits
 
+interface FmpFetchResult<T> {
+  data: T[];
+  responseSizeBytes: number;
+}
 
 async function fetchFmpData<T extends FmpStatementEntryBase>(
   baseUrl: string,
   symbol: string,
   statementType: string,
-  apiKey: string
-): Promise<T[]> {
+  apiKey: string,
+): Promise<FmpFetchResult<T>> {
   const fullUrl = `${baseUrl}?symbol=${symbol}&apikey=${apiKey}`;
 
   const controller = new AbortController();
@@ -38,8 +43,10 @@ async function fetchFmpData<T extends FmpStatementEntryBase>(
     response = await fetch(fullUrl, { signal: controller.signal });
   } catch (error) {
     clearTimeout(timeout);
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error(`FMP API request timed out after 10 seconds for ${statementType}.`);
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(
+        `FMP API request timed out after 10 seconds for ${statementType}.`,
+      );
     }
     throw error;
   } finally {
@@ -51,91 +58,112 @@ async function fetchFmpData<T extends FmpStatementEntryBase>(
     // CRITICAL: 429 rate limit errors should not be retried immediately
     // Retrying will just hit the rate limit again, wasting API calls
     if (response.status === 429) {
-      throw new Error(`RATE_LIMIT_429: FMP API rate limit reached for ${statementType}. ${errorText}`);
+      throw new Error(
+        `RATE_LIMIT_429: FMP API rate limit reached for ${statementType}. ${errorText}`,
+      );
     }
-    throw new Error(`FMP API error for ${statementType}: ${response.status} ${errorText}`);
+    throw new Error(
+      `FMP API error for ${statementType}: ${response.status} ${errorText}`,
+    );
   }
 
   // CRITICAL: Get the ACTUAL data transfer size (what FMP bills for)
-  const contentLength = response.headers.get('Content-Length');
+  const contentLength = response.headers.get("Content-Length");
   let actualSizeBytes = contentLength ? parseInt(contentLength, 10) : 0;
   if (actualSizeBytes === 0) {
-    console.warn(`[fetchFinancialStatementsLogic] Content-Length header missing for ${symbol}/${statementType}. Using fallback estimate.`);
+    console.warn(
+      `[fetchFinancialStatementsLogic] Content-Length header missing for ${symbol}/${statementType}. Using fallback estimate.`,
+    );
     actualSizeBytes = 200000; // 200 KB conservative estimate per statement type
   }
 
   const data: unknown = await response.json();
 
   if (!Array.isArray(data)) {
-    throw new Error(`Invalid data format for ${statementType}: Expected array, got ${typeof data}`);
+    throw new Error(
+      `Invalid data format for ${statementType}: Expected array, got ${typeof data}`,
+    );
   }
 
-  return data as T[];
+  return {
+    data: data as T[],
+    responseSizeBytes: actualSizeBytes,
+  };
 }
 
 export async function fetchFinancialStatementsLogic(
   job: QueueJob,
-  supabase: SupabaseClient
+  supabase: SupabaseClient,
 ): Promise<ProcessJobResult> {
   // CRITICAL VALIDATION #1: Data Type Check (Prevents Misconfiguration)
-  if (job.data_type !== 'financial-statements') {
+  if (job.data_type !== "financial-statements") {
     return {
       success: false,
       dataSizeBytes: 0,
-      error: `Configuration Error: fetchFinancialStatementsLogic was called for job type ${job.data_type}. Expected 'financial-statements'.`,
+      error:
+        `Configuration Error: fetchFinancialStatementsLogic was called for job type ${job.data_type}. Expected 'financial-statements'.`,
     };
   }
 
+  let totalDataSizeBytes = 0;
+
   try {
     if (!FMP_API_KEY) {
-      throw new Error('FMP_API_KEY environment variable is not set');
+      throw new Error("FMP_API_KEY environment variable is not set");
     }
 
     const statementsForSymbolUpsert: FinancialStatementRecord[] = [];
-    let totalDataSizeBytes = 0;
-
     // Fetch income statements
     await new Promise((resolve) => setTimeout(resolve, FMP_API_DELAY_MS));
-    const incomeStatements: FmpIncomeStatementEntry[] = await fetchFmpData<FmpIncomeStatementEntry>(
+    const incomeResult = await fetchFmpData<FmpIncomeStatementEntry>(
       INCOME_STATEMENT_ENDPOINT,
       job.symbol,
-      'Income Statement',
-      FMP_API_KEY
+      "Income Statement",
+      FMP_API_KEY,
     );
-    totalDataSizeBytes += incomeStatements.length > 0 ? 200000 : 0; // Estimate per statement type
+    const incomeStatements = incomeResult.data;
+    totalDataSizeBytes += incomeResult.responseSizeBytes;
 
     // Fetch balance sheets
     await new Promise((resolve) => setTimeout(resolve, FMP_API_DELAY_MS));
-    const balanceSheets: FmpBalanceSheetEntry[] = await fetchFmpData<FmpBalanceSheetEntry>(
+    const balanceSheetResult = await fetchFmpData<FmpBalanceSheetEntry>(
       BALANCE_SHEET_ENDPOINT,
       job.symbol,
-      'Balance Sheet',
-      FMP_API_KEY
+      "Balance Sheet",
+      FMP_API_KEY,
     );
-    totalDataSizeBytes += balanceSheets.length > 0 ? 200000 : 0;
+    const balanceSheets = balanceSheetResult.data;
+    totalDataSizeBytes += balanceSheetResult.responseSizeBytes;
 
     // Fetch cash flow statements
     await new Promise((resolve) => setTimeout(resolve, FMP_API_DELAY_MS));
-    const cashFlows: FmpCashFlowEntry[] = await fetchFmpData<FmpCashFlowEntry>(
+    const cashFlowResult = await fetchFmpData<FmpCashFlowEntry>(
       CASH_FLOW_ENDPOINT,
       job.symbol,
-      'Cash Flow',
-      FMP_API_KEY
+      "Cash Flow",
+      FMP_API_KEY,
     );
-    totalDataSizeBytes += cashFlows.length > 0 ? 200000 : 0;
+    const cashFlows = cashFlowResult.data;
+    totalDataSizeBytes += cashFlowResult.responseSizeBytes;
 
     // Use a Map to consolidate data by a unique key (date + period)
-    const consolidatedStatements = new Map<string, Partial<FinancialStatementRecord>>();
+    const consolidatedStatements = new Map<
+      string,
+      Partial<FinancialStatementRecord>
+    >();
 
     const allStatements = [
-      ...incomeStatements.map((s) => ({ ...s, type: 'income' })),
-      ...balanceSheets.map((s) => ({ ...s, type: 'balance' })),
-      ...cashFlows.map((s) => ({ ...s, type: 'cashflow' })),
+      ...incomeStatements.map((s) => ({ ...s, type: "income" })),
+      ...balanceSheets.map((s) => ({ ...s, type: "balance" })),
+      ...cashFlows.map((s) => ({ ...s, type: "cashflow" })),
     ];
 
     for (const stmt of allStatements) {
       if (!stmt.date || !stmt.period || !stmt.symbol) {
-        console.warn(`Skipping statement entry with missing key fields for ${job.symbol}:`, stmt);
+        console.warn(
+          `Skipping statement entry with missing key fields for ${job.symbol}:`,
+          stmt,
+        );
         continue;
       }
       const key = `${stmt.date}-${stmt.period}`;
@@ -152,13 +180,14 @@ export async function fetchFinancialStatementsLogic(
 
       // CRITICAL: Always update fetched_at when processing statements (even if record already exists)
       // Type assertion needed because fetched_at is optional in the type definition
-      (existing as FinancialStatementRecord & { fetched_at: string }).fetched_at = new Date().toISOString();
+      (existing as FinancialStatementRecord & { fetched_at: string })
+        .fetched_at = new Date().toISOString();
 
-      if (stmt.type === 'income') {
+      if (stmt.type === "income") {
         existing.income_statement_payload = stmt as FmpIncomeStatementEntry;
-      } else if (stmt.type === 'balance') {
+      } else if (stmt.type === "balance") {
         existing.balance_sheet_payload = stmt as FmpBalanceSheetEntry;
-      } else if (stmt.type === 'cashflow') {
+      } else if (stmt.type === "cashflow") {
         existing.cash_flow_payload = stmt as FmpCashFlowEntry;
       }
 
@@ -183,14 +212,19 @@ export async function fetchFinancialStatementsLogic(
     // For financial-statements, we use accepted_date (when SEC accepted the filing) as the source timestamp.
     // We check the MAX(accepted_date) for the symbol to detect if we're getting older data.
     const { data: registryData, error: registryError } = await supabase
-      .from('data_type_registry_v2')
-      .select('source_timestamp_column')
-      .eq('data_type', 'financial-statements')
+      .from("data_type_registry_v2")
+      .select("source_timestamp_column")
+      .eq("data_type", "financial-statements")
       .single();
 
     if (registryError) {
-      console.warn(`[fetchFinancialStatementsLogic] Failed to fetch registry for source timestamp check: ${registryError.message}`);
-    } else if (registryData?.source_timestamp_column && statementsForSymbolUpsert.length > 0) {
+      console.warn(
+        `[fetchFinancialStatementsLogic] Failed to fetch registry for source timestamp check: ${registryError.message}`,
+      );
+    } else if (
+      registryData?.source_timestamp_column &&
+      statementsForSymbolUpsert.length > 0
+    ) {
       // Get the maximum accepted_date from the new data
       const maxNewAcceptedDate = statementsForSymbolUpsert
         .map((stmt) => stmt.accepted_date)
@@ -202,48 +236,48 @@ export async function fetchFinancialStatementsLogic(
         // Get the maximum accepted_date from existing data for this symbol
         // CRITICAL: accepted_date is stored as TIMESTAMPTZ in the database
         const { data: existingData, error: existingError } = await supabase
-          .from('financial_statements')
-          .select('accepted_date')
-          .eq('symbol', job.symbol)
-          .not('accepted_date', 'is', null)
-          .order('accepted_date', { ascending: false })
+          .from("financial_statements")
+          .select("accepted_date")
+          .eq("symbol", job.symbol)
+          .not("accepted_date", "is", null)
+          .order("accepted_date", { ascending: false })
           .limit(1)
           .maybeSingle();
 
         if (existingError) {
-          console.warn(`[fetchFinancialStatementsLogic] Failed to fetch existing data for source timestamp check: ${existingError.message}`);
+          console.warn(
+            `[fetchFinancialStatementsLogic] Failed to fetch existing data for source timestamp check: ${existingError.message}`,
+          );
         } else if (existingData?.accepted_date) {
           // Parse timestamps - accepted_date is in format "YYYY-MM-DD HH:MM:SS" or ISO string
           const oldSourceTimestamp = new Date(existingData.accepted_date);
           const newSourceTimestamp = new Date(maxNewAcceptedDate);
 
           // Validate that dates are valid
-          if (isNaN(oldSourceTimestamp.getTime()) || isNaN(newSourceTimestamp.getTime())) {
-            console.warn(`[fetchFinancialStatementsLogic] Invalid timestamp format. Old: ${existingData.accepted_date}, New: ${maxNewAcceptedDate}`);
+          if (
+            isNaN(oldSourceTimestamp.getTime()) ||
+            isNaN(newSourceTimestamp.getTime())
+          ) {
+            console.warn(
+              `[fetchFinancialStatementsLogic] Invalid timestamp format. Old: ${existingData.accepted_date}, New: ${maxNewAcceptedDate}`,
+            );
           } else {
             // CRITICAL: If new source timestamp is < old source timestamp, this is stale data
             // The API is returning older filings (caching bug, stale cache, etc.)
             // We must reject this to prevent "data laundering"
-            // CRITICAL: For UI jobs (priority 1000), be more lenient - accept equal timestamps
-            // This prevents UI jobs from failing when the API returns the same data
-            const isUIJob = job.priority >= 1000;
             if (newSourceTimestamp < oldSourceTimestamp) {
-              // Stale data detected - this is expected behavior, not a failure
-              // Return success with message indicating data was correctly rejected
+              // Do not advance freshness when the source actually regresses.
+              // Returning a failure preserves the measured bandwidth and lets
+              // the queue's normal retry/backoff policy handle the anomaly.
               return {
-                success: true,
-                dataSizeBytes: 0,
-                message: `Data was stale (source timestamp: ${maxNewAcceptedDate} vs existing: ${existingData.accepted_date}). Correctly rejected to prevent data laundering.`,
-              };
-            } else if (!isUIJob && newSourceTimestamp.getTime() === oldSourceTimestamp.getTime()) {
-              // For non-UI jobs, reject equal timestamps (data laundering prevention)
-              return {
-                success: true,
-                dataSizeBytes: 0,
-                message: `Data was stale (equal timestamps: ${maxNewAcceptedDate}). Correctly rejected to prevent data laundering.`,
+                success: false,
+                dataSizeBytes: totalDataSizeBytes,
+                error:
+                  `FMP returned older financial statements for ${job.symbol} (source timestamp: ${maxNewAcceptedDate} vs existing: ${existingData.accepted_date}).`,
               };
             }
-            // For UI jobs, accept equal timestamps (user is actively waiting, better to show data than fail)
+            // Equal source timestamps are normal between filings. The fetch is
+            // still current evidence, so upsert it to advance fetched_at.
           }
         }
       }
@@ -251,18 +285,33 @@ export async function fetchFinancialStatementsLogic(
 
     if (statementsForSymbolUpsert.length > 0) {
       const { error: upsertError } = await supabase
-        .from('financial_statements')
+        .from("financial_statements")
         .upsert(statementsForSymbolUpsert, {
-          onConflict: 'symbol,date,period',
-          count: 'exact',
+          onConflict: "symbol,date,period",
+          count: "exact",
         });
 
       if (upsertError) {
         throw new Error(`Database upsert failed: ${upsertError.message}`);
       }
 
+      await recordDataFetchFreshness(
+        supabase,
+        job,
+        true,
+        totalDataSizeBytes,
+      );
     } else {
-      console.warn(`[fetchFinancialStatementsLogic] No consolidated statement data to upsert for ${job.symbol}`);
+      console.warn(
+        `[fetchFinancialStatementsLogic] No consolidated statement data to upsert for ${job.symbol}`,
+      );
+
+      await recordDataFetchFreshness(
+        supabase,
+        job,
+        false,
+        totalDataSizeBytes,
+      );
     }
 
     return {
@@ -272,9 +321,8 @@ export async function fetchFinancialStatementsLogic(
   } catch (error) {
     return {
       success: false,
-      dataSizeBytes: 0,
-      error: error instanceof Error ? error.message : 'Unknown error',
+      dataSizeBytes: totalDataSizeBytes,
+      error: error instanceof Error ? error.message : "Unknown error",
     };
   }
 }
-

--- a/supabase/functions/lib/fetch-fmp-profile.ts
+++ b/supabase/functions/lib/fetch-fmp-profile.ts
@@ -2,13 +2,14 @@
 // Library function for processing profile jobs from the queue
 // CRITICAL: This function is imported directly by queue-processor-v2 (monofunction architecture)
 
-import { z } from 'zod';
-import type { SupabaseClient } from '@supabase/supabase-js';
-import type { QueueJob, ProcessJobResult } from './types.ts';
+import { z } from "zod";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ProcessJobResult, QueueJob } from "./types.ts";
+import { recordDataFetchFreshness } from "./record-data-fetch-freshness.ts";
 
-const FMP_API_KEY = Deno.env.get('FMP_API_KEY');
-const FMP_PROFILE_BASE_URL = 'https://financialmodelingprep.com/stable/profile';
-const STORAGE_BUCKET_NAME = 'profile-images';
+const FMP_API_KEY = Deno.env.get("FMP_API_KEY");
+const FMP_PROFILE_BASE_URL = "https://financialmodelingprep.com/stable/profile";
+const STORAGE_BUCKET_NAME = "profile-images";
 
 // Zod schema for FMP Profile API response
 // CRITICAL: Strict schema validation - all required fields must be present and correct type
@@ -35,8 +36,8 @@ const FmpProfileSchema = z.object({
   website: z.union([
     z.string().url(), // Valid URL
     z.string(), // Any string (invalid URLs will be stored but not used)
-    z.literal(''),
-    z.null()
+    z.literal(""),
+    z.null(),
   ]).optional(), // FIXED: More lenient - accept any string, validate URL format later if needed
   description: z.string().nullish(), // FMP can return null or undefined
   ceo: z.string().nullish(), // FMP can return null or undefined
@@ -48,7 +49,7 @@ const FmpProfileSchema = z.object({
   city: z.string().nullish(), // FMP can return null or undefined
   state: z.string().nullish(), // FMP can return null or undefined
   zip: z.string().nullish(), // FMP can return null or undefined
-  image: z.string().url().optional().or(z.literal('')),
+  image: z.string().url().optional().or(z.literal("")),
   ipoDate: z.string().optional(), // "YYYY-MM-DD"
   defaultImage: z.boolean().optional(),
   isEtf: z.boolean().optional(),
@@ -57,22 +58,25 @@ const FmpProfileSchema = z.object({
   isFund: z.boolean().optional(),
 });
 
-function parseFmpFullTimeEmployees(employeesStr: string | undefined): number | null {
+function parseFmpFullTimeEmployees(
+  employeesStr: string | undefined,
+): number | null {
   if (!employeesStr) return null;
-  const num = parseInt(employeesStr.replace(/,/g, ''), 10);
+  const num = parseInt(employeesStr.replace(/,/g, ""), 10);
   return isNaN(num) ? null : num;
 }
 
 export async function fetchProfileLogic(
   job: QueueJob,
-  supabase: SupabaseClient
+  supabase: SupabaseClient,
 ): Promise<ProcessJobResult> {
   // CRITICAL VALIDATION #1: Data Type Check (Prevents Misconfiguration)
-  if (job.data_type !== 'profile') {
+  if (job.data_type !== "profile") {
     return {
       success: false,
       dataSizeBytes: 0,
-      error: `Configuration Error: fetchProfileLogic was called for job type ${job.data_type}. Expected 'profile'.`,
+      error:
+        `Configuration Error: fetchProfileLogic was called for job type ${job.data_type}. Expected 'profile'.`,
     };
   }
 
@@ -83,11 +87,14 @@ export async function fetchProfileLogic(
 
     let response: Response;
     try {
-      const profileUrl = `${FMP_PROFILE_BASE_URL}?symbol=${job.symbol}&apikey=${FMP_API_KEY}`;
+      const profileUrl =
+        `${FMP_PROFILE_BASE_URL}?symbol=${job.symbol}&apikey=${FMP_API_KEY}`;
       response = await fetch(profileUrl, { signal: controller.signal });
     } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        throw new Error('FMP API request timed out after 10 seconds. This indicates API brownout or network issue.');
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(
+          "FMP API request timed out after 10 seconds. This indicates API brownout or network issue.",
+        );
       }
       throw error;
     } finally {
@@ -95,15 +102,19 @@ export async function fetchProfileLogic(
     }
 
     if (!response.ok) {
-      throw new Error(`FMP API error: ${response.status} ${response.statusText}`);
+      throw new Error(
+        `FMP API error: ${response.status} ${response.statusText}`,
+      );
     }
 
     // CRITICAL: Get the ACTUAL data transfer size (what FMP bills for)
     // Do NOT use JSON.stringify().length - that measures the parsed object, not the HTTP payload
-    const contentLength = response.headers.get('Content-Length');
+    const contentLength = response.headers.get("Content-Length");
     let actualSizeBytes = contentLength ? parseInt(contentLength, 10) : 0;
     if (actualSizeBytes === 0) {
-      console.warn(`[fetchProfileLogic] Content-Length header missing for ${job.symbol}. Using fallback estimate.`);
+      console.warn(
+        `[fetchProfileLogic] Content-Length header missing for ${job.symbol}. Using fallback estimate.`,
+      );
       actualSizeBytes = 50000; // 50 KB conservative estimate
     }
 
@@ -113,8 +124,26 @@ export async function fetchProfileLogic(
     // Manual "spot-checks" are insufficient - APIs can change field names without versioning
     // This causes undefined values to be written as NULL, corrupting the database
     // MUST use strict, holistic schema parsing (Zod) to validate the ENTIRE response
-    if (!Array.isArray(data) || data.length === 0) {
-      throw new Error(`FMP API returned empty array or invalid response for ${job.symbol}`);
+    if (!Array.isArray(data)) {
+      throw new Error(
+        `FMP API returned invalid response for ${job.symbol}. Expected an array.`,
+      );
+    }
+
+    if (data.length === 0) {
+      await recordDataFetchFreshness(
+        supabase,
+        job,
+        false,
+        actualSizeBytes,
+      );
+
+      return {
+        success: true,
+        dataSizeBytes: actualSizeBytes,
+        message:
+          `No profile data found for ${job.symbol}. Recorded successful empty freshness.`,
+      };
     }
 
     // Parse the data - this IS the validation
@@ -140,22 +169,28 @@ export async function fetchProfileLogic(
           .list(undefined, { limit: 1, search: imageFileName });
 
         if (listError) {
-          console.warn(`[fetchProfileLogic] Storage list error for ${job.symbol}: ${listError.message}`);
+          console.warn(
+            `[fetchProfileLogic] Storage list error for ${job.symbol}: ${listError.message}`,
+          );
         } else if (!existingFiles || existingFiles.length === 0) {
           const imageResponse = await fetch(profile.image);
           if (!imageResponse.ok) {
-            console.warn(`[fetchProfileLogic] Failed to download image for ${job.symbol}`);
+            console.warn(
+              `[fetchProfileLogic] Failed to download image for ${job.symbol}`,
+            );
           } else {
             const imageBlob = await imageResponse.blob();
             const { error: uploadError } = await supabase.storage
               .from(STORAGE_BUCKET_NAME)
               .upload(imageFileName, imageBlob, {
-                contentType: 'image/png',
+                contentType: "image/png",
                 upsert: false,
               });
 
             if (uploadError) {
-              console.warn(`[fetchProfileLogic] Upload error for ${job.symbol}: ${uploadError.message}`);
+              console.warn(
+                `[fetchProfileLogic] Upload error for ${job.symbol}: ${uploadError.message}`,
+              );
             } else {
               const { data: urlData } = supabase.storage
                 .from(STORAGE_BUCKET_NAME)
@@ -170,7 +205,9 @@ export async function fetchProfileLogic(
           finalImageUrl = urlData.publicUrl;
         }
       } catch (imageError) {
-        console.warn(`[fetchProfileLogic] Image processing failed for ${job.symbol}: ${imageError}`);
+        console.warn(
+          `[fetchProfileLogic] Image processing failed for ${job.symbol}: ${imageError}`,
+        );
         finalImageUrl = profile.image || null;
       }
     }
@@ -182,7 +219,9 @@ export async function fetchProfileLogic(
       symbol: profile.symbol,
       price: profile.price,
       beta: profile.beta ?? null,
-      average_volume: profile.averageVolume ? Math.trunc(profile.averageVolume) : null,
+      average_volume: profile.averageVolume
+        ? Math.trunc(profile.averageVolume)
+        : null,
       market_cap: profile.marketCap ? Math.trunc(profile.marketCap) : null,
       last_dividend: profile.lastDividend ?? null,
       range: profile.range ?? null,
@@ -196,12 +235,16 @@ export async function fetchProfileLogic(
       exchange: profile.exchange ?? null,
       exchange_full_name: profile.exchangeFullName ?? null,
       industry: profile.industry ?? null,
-      website: (profile.website && profile.website !== '') ? profile.website : null, // Store null for empty strings or invalid URLs
+      website: (profile.website && profile.website !== "")
+        ? profile.website
+        : null, // Store null for empty strings or invalid URLs
       description: profile.description ?? null,
       ceo: profile.ceo ?? null,
       sector: profile.sector ?? null,
       country: profile.country ?? null,
-      full_time_employees: parseFmpFullTimeEmployees(profile.fullTimeEmployees ?? undefined),
+      full_time_employees: parseFmpFullTimeEmployees(
+        profile.fullTimeEmployees ?? undefined,
+      ),
       phone: profile.phone ?? null,
       address: profile.address ?? null,
       city: profile.city ?? null,
@@ -218,13 +261,20 @@ export async function fetchProfileLogic(
     };
 
     // Upsert to database using RPC function
-    const { error: rpcError } = await supabase.rpc('upsert_profile', {
+    const { error: rpcError } = await supabase.rpc("upsert_profile", {
       profile_data: recordToUpsert,
     });
 
     if (rpcError) {
       throw new Error(`Database upsert failed: ${rpcError.message}`);
     }
+
+    await recordDataFetchFreshness(
+      supabase,
+      job,
+      true,
+      actualSizeBytes,
+    );
 
     return {
       success: true,
@@ -234,8 +284,7 @@ export async function fetchProfileLogic(
     return {
       success: false,
       dataSizeBytes: 0,
-      error: error instanceof Error ? error.message : 'Unknown error',
+      error: error instanceof Error ? error.message : "Unknown error",
     };
   }
 }
-

--- a/supabase/functions/lib/fetch-fmp-ratios-ttm.ts
+++ b/supabase/functions/lib/fetch-fmp-ratios-ttm.ts
@@ -2,35 +2,38 @@
 // Library function for processing ratios-ttm jobs from the queue
 // CRITICAL: This function is imported directly by queue-processor-v2 (monofunction architecture)
 
-import type { SupabaseClient } from '@supabase/supabase-js';
-import type { QueueJob, ProcessJobResult } from './types.ts';
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ProcessJobResult, QueueJob } from "./types.ts";
+import { recordDataFetchFreshness } from "./record-data-fetch-freshness.ts";
 
 // Import types from the original Edge Function
 import type {
   FmpRatiosTtmData,
   SupabaseRatiosTtmRecord,
-} from '../fetch-fmp-ratios-ttm/types.ts';
+} from "../fetch-fmp-ratios-ttm/types.ts";
 // Note: SupabaseRatiosTtmRecord includes fetched_at?: string
 
-const FMP_API_KEY = Deno.env.get('FMP_API_KEY');
-const FMP_RATIOS_TTM_BASE_URL = 'https://financialmodelingprep.com/stable/ratios-ttm';
+const FMP_API_KEY = Deno.env.get("FMP_API_KEY");
+const FMP_RATIOS_TTM_BASE_URL =
+  "https://financialmodelingprep.com/stable/ratios-ttm";
 
 export async function fetchRatiosTtmLogic(
   job: QueueJob,
-  supabase: SupabaseClient
+  supabase: SupabaseClient,
 ): Promise<ProcessJobResult> {
   // CRITICAL VALIDATION #1: Data Type Check (Prevents Misconfiguration)
-  if (job.data_type !== 'ratios-ttm') {
+  if (job.data_type !== "ratios-ttm") {
     return {
       success: false,
       dataSizeBytes: 0,
-      error: `Configuration Error: fetchRatiosTtmLogic was called for job type ${job.data_type}. Expected 'ratios-ttm'.`,
+      error:
+        `Configuration Error: fetchRatiosTtmLogic was called for job type ${job.data_type}. Expected 'ratios-ttm'.`,
     };
   }
 
   try {
     if (!FMP_API_KEY) {
-      throw new Error('FMP_API_KEY environment variable is not set');
+      throw new Error("FMP_API_KEY environment variable is not set");
     }
 
     // CRITICAL: Aggressive internal timeout (prevents "Slow API" throughput collapse)
@@ -39,12 +42,15 @@ export async function fetchRatiosTtmLogic(
 
     let response: Response;
     try {
-      const ratiosUrl = `${FMP_RATIOS_TTM_BASE_URL}?symbol=${job.symbol}&apikey=${FMP_API_KEY}`;
+      const ratiosUrl =
+        `${FMP_RATIOS_TTM_BASE_URL}?symbol=${job.symbol}&apikey=${FMP_API_KEY}`;
       response = await fetch(ratiosUrl, { signal: controller.signal });
     } catch (error) {
       clearTimeout(timeout);
-      if (error instanceof Error && error.name === 'AbortError') {
-        throw new Error('FMP API request timed out after 10 seconds. This indicates API brownout or network issue.');
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(
+          "FMP API request timed out after 10 seconds. This indicates API brownout or network issue.",
+        );
       }
       throw error;
     } finally {
@@ -57,104 +63,51 @@ export async function fetchRatiosTtmLogic(
     }
 
     // CRITICAL: Get the ACTUAL data transfer size (what FMP bills for)
-    const contentLength = response.headers.get('Content-Length');
+    const contentLength = response.headers.get("Content-Length");
     let actualSizeBytes = contentLength ? parseInt(contentLength, 10) : 0;
     if (actualSizeBytes === 0) {
-      console.warn(`[fetchRatiosTtmLogic] Content-Length header missing for ${job.symbol}. Using fallback estimate.`);
+      console.warn(
+        `[fetchRatiosTtmLogic] Content-Length header missing for ${job.symbol}. Using fallback estimate.`,
+      );
       actualSizeBytes = 50000; // 50 KB conservative estimate
     }
 
     const fmpRatiosResult: unknown = await response.json();
 
-    // Handle empty array response - create sentinel record to prevent infinite retries
-    if (!Array.isArray(fmpRatiosResult) || fmpRatiosResult.length === 0) {
-      // Create a sentinel record with fetched_at to mark that we checked and found no data
-      // This prevents the staleness checker from continuously re-queueing jobs
-      const sentinelRecord: SupabaseRatiosTtmRecord = {
-        symbol: job.symbol,
-        // Set all numeric fields to null (sentinel record)
-        gross_profit_margin_ttm: null,
-        ebit_margin_ttm: null,
-        ebitda_margin_ttm: null,
-        operating_profit_margin_ttm: null,
-        pretax_profit_margin_ttm: null,
-        continuous_operations_profit_margin_ttm: null,
-        net_profit_margin_ttm: null,
-        bottom_line_profit_margin_ttm: null,
-        receivables_turnover_ttm: null,
-        payables_turnover_ttm: null,
-        inventory_turnover_ttm: null,
-        fixed_asset_turnover_ttm: null,
-        asset_turnover_ttm: null,
-        current_ratio_ttm: null,
-        quick_ratio_ttm: null,
-        solvency_ratio_ttm: null,
-        cash_ratio_ttm: null,
-        price_to_earnings_ratio_ttm: null,
-        price_to_earnings_growth_ratio_ttm: null,
-        forward_price_to_earnings_growth_ratio_ttm: null,
-        price_to_book_ratio_ttm: null,
-        price_to_sales_ratio_ttm: null,
-        price_to_free_cash_flow_ratio_ttm: null,
-        price_to_operating_cash_flow_ratio_ttm: null,
-        debt_to_assets_ratio_ttm: null,
-        debt_to_equity_ratio_ttm: null,
-        debt_to_capital_ratio_ttm: null,
-        long_term_debt_to_capital_ratio_ttm: null,
-        financial_leverage_ratio_ttm: null,
-        working_capital_turnover_ratio_ttm: null,
-        operating_cash_flow_ratio_ttm: null,
-        operating_cash_flow_sales_ratio_ttm: null,
-        free_cash_flow_operating_cash_flow_ratio_ttm: null,
-        debt_service_coverage_ratio_ttm: null,
-        interest_coverage_ratio_ttm: null,
-        short_term_operating_cash_flow_coverage_ratio_ttm: null,
-        operating_cash_flow_coverage_ratio_ttm: null,
-        capital_expenditure_coverage_ratio_ttm: null,
-        dividend_paid_and_capex_coverage_ratio_ttm: null,
-        dividend_payout_ratio_ttm: null,
-        dividend_yield_ttm: null,
-        enterprise_value_ttm: null,
-        revenue_per_share_ttm: null,
-        net_income_per_share_ttm: null,
-        interest_debt_per_share_ttm: null,
-        cash_per_share_ttm: null,
-        book_value_per_share_ttm: null,
-        tangible_book_value_per_share_ttm: null,
-        shareholders_equity_per_share_ttm: null,
-        operating_cash_flow_per_share_ttm: null,
-        capex_per_share_ttm: null,
-        free_cash_flow_per_share_ttm: null,
-        net_income_per_ebt_ttm: null,
-        ebt_per_ebit_ttm: null,
-        price_to_fair_value_ttm: null,
-        debt_to_market_cap_ttm: null,
-        effective_tax_rate_ttm: null,
-        enterprise_value_multiple_ttm: null,
-        dividend_per_share_ttm: null,
-        fetched_at: new Date().toISOString(), // Mark as fetched to prevent re-queueing
-      } as SupabaseRatiosTtmRecord;
+    if (!Array.isArray(fmpRatiosResult)) {
+      throw new Error(
+        `FMP API returned invalid ratios response for ${job.symbol}. Expected an array.`,
+      );
+    }
 
-      const { error: upsertError } = await supabase
-        .from('ratios_ttm')
-        .upsert(sentinelRecord, { onConflict: 'symbol' });
-
-      if (upsertError) {
-        throw new Error(`Database upsert failed for sentinel record: ${upsertError.message}`);
-      }
-
-      console.log(`[fetchRatiosTtmLogic] FMP API returned empty array for ${job.symbol}. Created sentinel record.`);
+    // A valid empty response is freshness evidence, not business data. Keep any
+    // existing ratios row intact instead of overwriting it with an all-null
+    // sentinel that could corrupt the Compass calculation.
+    if (fmpRatiosResult.length === 0) {
+      await recordDataFetchFreshness(
+        supabase,
+        job,
+        false,
+        actualSizeBytes,
+      );
 
       return {
         success: true,
         dataSizeBytes: actualSizeBytes,
+        message:
+          `No ratios data found for ${job.symbol}. Recorded successful empty freshness.`,
       };
     }
 
     const ratiosData = fmpRatiosResult[0] as FmpRatiosTtmData;
 
-    if (!ratiosData || typeof ratiosData.symbol !== 'string' || ratiosData.symbol.trim() === '') {
-      throw new Error(`Empty or invalid TTM ratios data object from FMP for ${job.symbol}`);
+    if (
+      !ratiosData || typeof ratiosData.symbol !== "string" ||
+      ratiosData.symbol.trim() === ""
+    ) {
+      throw new Error(
+        `Empty or invalid TTM ratios data object from FMP for ${job.symbol}`,
+      );
     }
 
     // CRITICAL VALIDATION #3: Source Timestamp Check (if available in registry)
@@ -172,7 +125,8 @@ export async function fetchRatiosTtmLogic(
       ebitda_margin_ttm: ratiosData.ebitdaMarginTTM,
       operating_profit_margin_ttm: ratiosData.operatingProfitMarginTTM,
       pretax_profit_margin_ttm: ratiosData.pretaxProfitMarginTTM,
-      continuous_operations_profit_margin_ttm: ratiosData.continuousOperationsProfitMarginTTM,
+      continuous_operations_profit_margin_ttm:
+        ratiosData.continuousOperationsProfitMarginTTM,
       net_profit_margin_ttm: ratiosData.netProfitMarginTTM,
       bottom_line_profit_margin_ttm: ratiosData.bottomLineProfitMarginTTM,
       receivables_turnover_ttm: ratiosData.receivablesTurnoverTTM,
@@ -185,27 +139,38 @@ export async function fetchRatiosTtmLogic(
       solvency_ratio_ttm: ratiosData.solvencyRatioTTM,
       cash_ratio_ttm: ratiosData.cashRatioTTM,
       price_to_earnings_ratio_ttm: ratiosData.priceToEarningsRatioTTM,
-      price_to_earnings_growth_ratio_ttm: ratiosData.priceToEarningsGrowthRatioTTM,
-      forward_price_to_earnings_growth_ratio_ttm: ratiosData.forwardPriceToEarningsGrowthRatioTTM,
+      price_to_earnings_growth_ratio_ttm:
+        ratiosData.priceToEarningsGrowthRatioTTM,
+      forward_price_to_earnings_growth_ratio_ttm:
+        ratiosData.forwardPriceToEarningsGrowthRatioTTM,
       price_to_book_ratio_ttm: ratiosData.priceToBookRatioTTM,
       price_to_sales_ratio_ttm: ratiosData.priceToSalesRatioTTM,
       price_to_free_cash_flow_ratio_ttm: ratiosData.priceToFreeCashFlowRatioTTM,
-      price_to_operating_cash_flow_ratio_ttm: ratiosData.priceToOperatingCashFlowRatioTTM,
+      price_to_operating_cash_flow_ratio_ttm:
+        ratiosData.priceToOperatingCashFlowRatioTTM,
       debt_to_assets_ratio_ttm: ratiosData.debtToAssetsRatioTTM,
       debt_to_equity_ratio_ttm: ratiosData.debtToEquityRatioTTM,
       debt_to_capital_ratio_ttm: ratiosData.debtToCapitalRatioTTM,
-      long_term_debt_to_capital_ratio_ttm: ratiosData.longTermDebtToCapitalRatioTTM,
+      long_term_debt_to_capital_ratio_ttm:
+        ratiosData.longTermDebtToCapitalRatioTTM,
       financial_leverage_ratio_ttm: ratiosData.financialLeverageRatioTTM,
-      working_capital_turnover_ratio_ttm: ratiosData.workingCapitalTurnoverRatioTTM,
+      working_capital_turnover_ratio_ttm:
+        ratiosData.workingCapitalTurnoverRatioTTM,
       operating_cash_flow_ratio_ttm: ratiosData.operatingCashFlowRatioTTM,
-      operating_cash_flow_sales_ratio_ttm: ratiosData.operatingCashFlowSalesRatioTTM,
-      free_cash_flow_operating_cash_flow_ratio_ttm: ratiosData.freeCashFlowOperatingCashFlowRatioTTM,
+      operating_cash_flow_sales_ratio_ttm:
+        ratiosData.operatingCashFlowSalesRatioTTM,
+      free_cash_flow_operating_cash_flow_ratio_ttm:
+        ratiosData.freeCashFlowOperatingCashFlowRatioTTM,
       debt_service_coverage_ratio_ttm: ratiosData.debtServiceCoverageRatioTTM,
       interest_coverage_ratio_ttm: ratiosData.interestCoverageRatioTTM,
-      short_term_operating_cash_flow_coverage_ratio_ttm: ratiosData.shortTermOperatingCashFlowCoverageRatioTTM,
-      operating_cash_flow_coverage_ratio_ttm: ratiosData.operatingCashFlowCoverageRatioTTM,
-      capital_expenditure_coverage_ratio_ttm: ratiosData.capitalExpenditureCoverageRatioTTM,
-      dividend_paid_and_capex_coverage_ratio_ttm: ratiosData.dividendPaidAndCapexCoverageRatioTTM,
+      short_term_operating_cash_flow_coverage_ratio_ttm:
+        ratiosData.shortTermOperatingCashFlowCoverageRatioTTM,
+      operating_cash_flow_coverage_ratio_ttm:
+        ratiosData.operatingCashFlowCoverageRatioTTM,
+      capital_expenditure_coverage_ratio_ttm:
+        ratiosData.capitalExpenditureCoverageRatioTTM,
+      dividend_paid_and_capex_coverage_ratio_ttm:
+        ratiosData.dividendPaidAndCapexCoverageRatioTTM,
       dividend_payout_ratio_ttm: ratiosData.dividendPayoutRatioTTM,
       dividend_yield_ttm: ratiosData.dividendYieldTTM,
       enterprise_value_ttm: ratiosData.enterpriseValueTTM,
@@ -214,9 +179,12 @@ export async function fetchRatiosTtmLogic(
       interest_debt_per_share_ttm: ratiosData.interestDebtPerShareTTM,
       cash_per_share_ttm: ratiosData.cashPerShareTTM,
       book_value_per_share_ttm: ratiosData.bookValuePerShareTTM,
-      tangible_book_value_per_share_ttm: ratiosData.tangibleBookValuePerShareTTM,
-      shareholders_equity_per_share_ttm: ratiosData.shareholdersEquityPerShareTTM,
-      operating_cash_flow_per_share_ttm: ratiosData.operatingCashFlowPerShareTTM,
+      tangible_book_value_per_share_ttm:
+        ratiosData.tangibleBookValuePerShareTTM,
+      shareholders_equity_per_share_ttm:
+        ratiosData.shareholdersEquityPerShareTTM,
+      operating_cash_flow_per_share_ttm:
+        ratiosData.operatingCashFlowPerShareTTM,
       capex_per_share_ttm: ratiosData.capexPerShareTTM,
       free_cash_flow_per_share_ttm: ratiosData.freeCashFlowPerShareTTM,
       net_income_per_ebt_ttm: ratiosData.netIncomePerEBTTTM,
@@ -230,13 +198,19 @@ export async function fetchRatiosTtmLogic(
     } as SupabaseRatiosTtmRecord;
 
     const { error: upsertError } = await supabase
-      .from('ratios_ttm')
-      .upsert(recordToUpsert, { onConflict: 'symbol', count: 'exact' });
+      .from("ratios_ttm")
+      .upsert(recordToUpsert, { onConflict: "symbol", count: "exact" });
 
     if (upsertError) {
       throw new Error(`Database upsert failed: ${upsertError.message}`);
     }
 
+    await recordDataFetchFreshness(
+      supabase,
+      job,
+      true,
+      actualSizeBytes,
+    );
 
     return {
       success: true,
@@ -246,8 +220,7 @@ export async function fetchRatiosTtmLogic(
     return {
       success: false,
       dataSizeBytes: 0,
-      error: error instanceof Error ? error.message : 'Unknown error',
+      error: error instanceof Error ? error.message : "Unknown error",
     };
   }
 }
-

--- a/supabase/migrations/20260731000000_restore_scheduled_refresh_baseline.sql
+++ b/supabase/migrations/20260731000000_restore_scheduled_refresh_baseline.sql
@@ -1,0 +1,497 @@
+-- Restore scheduled refreshes as the baseline for durable Compass inputs.
+--
+-- The quota incident required temporarily disabling the scheduler. It did not
+-- change the desired steady state: every active listed symbol should receive
+-- TTL-driven background refreshes, while presence remains a priority overlay.
+-- Quotes stay on demand because a one-minute full-universe quote sweep would
+-- waste bandwidth without improving the durable recommendation inputs.
+
+BEGIN;
+
+-- A durable data type may need both scheduled coverage and an on-demand
+-- priority boost. Model that explicitly instead of making the two mechanisms
+-- mutually exclusive.
+DO $$
+DECLARE
+  v_constraint_name text;
+BEGIN
+  FOR v_constraint_name IN
+    SELECT constraint_row.conname
+    FROM pg_constraint AS constraint_row
+    WHERE constraint_row.conrelid =
+          'public.data_type_registry_v2'::regclass
+      AND constraint_row.contype = 'c'
+      AND pg_get_constraintdef(constraint_row.oid)
+          ILIKE '%refresh_strategy%'
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE public.data_type_registry_v2 DROP CONSTRAINT %I',
+      v_constraint_name
+    );
+  END LOOP;
+END;
+$$;
+
+ALTER TABLE public.data_type_registry_v2
+  ADD CONSTRAINT data_type_registry_v2_refresh_strategy_v2_check
+  CHECK (refresh_strategy IN ('on-demand', 'scheduled', 'hybrid'));
+
+COMMENT ON COLUMN public.data_type_registry_v2.refresh_strategy IS
+  'Refresh mode: on-demand, scheduled, or hybrid. Hybrid uses scheduled TTL coverage with presence-driven priority boosts.';
+
+CREATE INDEX IF NOT EXISTS
+  idx_data_type_registry_v2_refresh_strategy_hybrid
+  ON public.data_type_registry_v2(refresh_strategy)
+  WHERE refresh_strategy = 'hybrid';
+
+-- These are the durable inputs used directly by Compass ranking, plus the
+-- low-bandwidth insider statistics companion. Profile data also supplies the
+-- exchange/industry filters. Financial statements move from 30 days to one
+-- week so the weekly recommendation cannot be based on a month-old fetch.
+UPDATE public.data_type_registry_v2
+SET
+  refresh_strategy = 'hybrid',
+  default_ttl_minutes = CASE data_type
+    WHEN 'financial-statements' THEN 10080
+    ELSE default_ttl_minutes
+  END,
+  updated_at = now()
+WHERE data_type IN (
+  'profile',
+  'financial-statements',
+  'ratios-ttm',
+  'insider-transactions',
+  'insider-trading-statistics'
+);
+
+-- SEC outstanding-share jobs are already queued by the profile upsert trigger.
+-- Scheduling the same type across the full universe would consume processor
+-- capacity twice without spending or saving any FMP quota.
+UPDATE public.data_type_registry_v2
+SET
+  refresh_strategy = 'on-demand',
+  updated_at = now()
+WHERE data_type = 'sec-outstanding-shares';
+
+-- Scheduled work must stay below every demand-driven priority, including the
+-- special financial-statements boost.
+CREATE OR REPLACE FUNCTION public.queue_refresh_if_not_exists_v2(
+  p_symbol text,
+  p_data_type text,
+  p_priority integer,
+  p_estimated_size_bytes bigint DEFAULT 0
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SET search_path = public, extensions
+AS $$
+DECLARE
+  job_id uuid;
+  existing_job_id uuid;
+  final_priority integer;
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(p_symbol || chr(31) || p_data_type, 0)
+  );
+
+  IF p_data_type = 'financial-statements'
+     AND p_priority >= 0
+     AND p_priority < 1000
+  THEN
+    final_priority := 500;
+  ELSE
+    final_priority := p_priority;
+  END IF;
+
+  SELECT queue.id
+  INTO existing_job_id
+  FROM public.api_call_queue_v2 AS queue
+  WHERE queue.symbol = p_symbol
+    AND queue.data_type = p_data_type
+    AND queue.status IN ('pending', 'processing')
+  ORDER BY queue.created_at
+  LIMIT 1;
+
+  IF existing_job_id IS NOT NULL THEN
+    UPDATE public.api_call_queue_v2 AS queue
+    SET priority = GREATEST(queue.priority, final_priority)
+    WHERE queue.id = existing_job_id
+      AND queue.status IN ('pending', 'processing');
+    job_id := existing_job_id;
+  ELSE
+    INSERT INTO public.api_call_queue_v2 (
+      symbol,
+      data_type,
+      status,
+      priority,
+      estimated_data_size_bytes
+    )
+    VALUES (
+      p_symbol,
+      p_data_type,
+      'pending',
+      final_priority,
+      p_estimated_size_bytes
+    )
+    RETURNING api_call_queue_v2.id INTO job_id;
+  END IF;
+
+  RETURN job_id;
+END;
+$$;
+
+-- Presence is an accelerator for both on-demand and hybrid types. It is not
+-- the source of scheduled coverage.
+CREATE OR REPLACE FUNCTION public.check_and_queue_stale_data_from_presence_v2()
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = public, extensions
+AS $$
+DECLARE
+  reg_row RECORD;
+  symbol_row RECORD;
+  sql_text TEXT;
+  lock_acquired BOOLEAN;
+  start_time TIMESTAMPTZ := clock_timestamp();
+  max_duration_seconds INTEGER := 50;
+  symbols_processed INTEGER := 0;
+  max_symbols_per_run INTEGER := 1000;
+  exchange_is_open BOOLEAN;
+  data_exists BOOLEAN;
+  source_fetched_at TIMESTAMPTZ;
+  effective_fetched_at TIMESTAMPTZ;
+  is_stale BOOLEAN;
+  is_super_stale BOOLEAN;
+  user_count INTEGER;
+  queue_priority INTEGER;
+BEGIN
+  SELECT pg_try_advisory_lock(42) INTO lock_acquired;
+  IF NOT lock_acquired THEN
+    RETURN;
+  END IF;
+
+  BEGIN
+    IF public.is_quota_exceeded_v2() THEN
+      PERFORM pg_advisory_unlock(42);
+      RETURN;
+    END IF;
+
+    FOR symbol_row IN
+      SELECT DISTINCT symbol
+      FROM public.get_active_subscriptions_from_realtime()
+      WHERE symbol IS NOT NULL
+      LIMIT max_symbols_per_run
+    LOOP
+      IF EXTRACT(EPOCH FROM (clock_timestamp() - start_time))
+         > max_duration_seconds
+      THEN
+        PERFORM pg_advisory_unlock(42);
+        RETURN;
+      END IF;
+
+      symbols_processed := symbols_processed + 1;
+
+      FOR reg_row IN
+        SELECT DISTINCT registry.*
+        FROM public.data_type_registry_v2 registry
+        INNER JOIN public.get_active_subscriptions_from_realtime() subscription
+          ON subscription.symbol = symbol_row.symbol
+         AND subscription.data_type = registry.data_type
+        WHERE registry.refresh_strategy IN ('on-demand', 'hybrid')
+      LOOP
+        IF EXTRACT(EPOCH FROM (clock_timestamp() - start_time))
+           > max_duration_seconds
+        THEN
+          PERFORM pg_advisory_unlock(42);
+          RETURN;
+        END IF;
+
+        IF NOT public.is_valid_identifier(reg_row.table_name)
+           OR NOT public.is_valid_identifier(reg_row.symbol_column)
+           OR NOT public.is_valid_identifier(reg_row.timestamp_column)
+           OR NOT public.is_valid_identifier(reg_row.staleness_function)
+        THEN
+          CONTINUE;
+        END IF;
+
+        BEGIN
+          sql_text := format(
+            'SELECT COUNT(*) > 0, MAX(t.%I) FROM %I t WHERE t.%I = %L',
+            reg_row.timestamp_column,
+            reg_row.table_name,
+            reg_row.symbol_column,
+            symbol_row.symbol
+          );
+          EXECUTE sql_text INTO data_exists, source_fetched_at;
+
+          IF reg_row.data_type = 'quote' AND data_exists THEN
+            SELECT public.is_exchange_open_for_symbol_v2(
+              symbol_row.symbol,
+              'quote'
+            )
+            INTO exchange_is_open;
+
+            IF NOT exchange_is_open THEN
+              sql_text := format(
+                'SELECT %I($1, 1440)',
+                reg_row.staleness_function
+              );
+              EXECUTE sql_text USING source_fetched_at INTO is_super_stale;
+
+              IF NOT COALESCE(is_super_stale, TRUE) THEN
+                CONTINUE;
+              END IF;
+            END IF;
+          END IF;
+
+          effective_fetched_at :=
+            public.effective_data_fetch_timestamp_v2(
+              symbol_row.symbol,
+              reg_row.data_type,
+              source_fetched_at
+            );
+
+          sql_text := format(
+            'SELECT %I($1, $2)',
+            reg_row.staleness_function
+          );
+          EXECUTE sql_text
+            USING effective_fetched_at, reg_row.default_ttl_minutes
+            INTO is_stale;
+
+          IF COALESCE(is_stale, TRUE) THEN
+            SELECT COUNT(DISTINCT subscription.user_id)::INTEGER
+            INTO user_count
+            FROM public.get_active_subscriptions_from_realtime() subscription
+            WHERE subscription.symbol = symbol_row.symbol
+              AND subscription.data_type = reg_row.data_type;
+
+            queue_priority := CASE
+              WHEN reg_row.data_type = 'financial-statements'
+                   AND user_count < 1000
+                THEN 500
+              ELSE GREATEST(user_count, 1)
+            END;
+
+            PERFORM public.queue_refresh_if_not_exists_v2(
+              symbol_row.symbol,
+              reg_row.data_type,
+              queue_priority,
+              reg_row.estimated_data_size_bytes
+            );
+          END IF;
+        EXCEPTION
+          WHEN OTHERS THEN
+            RAISE WARNING
+              'Presence staleness check failed for symbol % and type %: %',
+              symbol_row.symbol,
+              reg_row.data_type,
+              SQLERRM;
+            CONTINUE;
+        END;
+      END LOOP;
+    END LOOP;
+
+    INSERT INTO public.cron_health_logs (jobname, last_run)
+    VALUES ('check-stale-data-v2', NOW())
+    ON CONFLICT (jobname) DO UPDATE
+    SET last_run = EXCLUDED.last_run;
+
+    PERFORM pg_advisory_unlock(42);
+  EXCEPTION
+    WHEN OTHERS THEN
+      PERFORM pg_advisory_unlock(42);
+      RAISE;
+  END;
+END;
+$$;
+
+COMMENT ON FUNCTION public.check_and_queue_stale_data_from_presence_v2() IS
+  'Presence-driven priority overlay for on-demand and hybrid data. Scheduled coverage is handled independently by queue_scheduled_refreshes_v2.';
+
+-- Efficient oldest-first scans need the ordering column in the active-symbol
+-- index. This avoids sorting the full universe every minute.
+CREATE INDEX IF NOT EXISTS idx_listed_symbols_active_last_processed
+  ON public.listed_symbols(last_processed_at ASC NULLS FIRST, symbol)
+  WHERE is_active = true;
+
+-- Fill at most a two-batch pending buffer. The batch limit is taken from the
+-- active quota calibration, so the temporary 25-job recovery policy remains
+-- authoritative until a new dashboard snapshot is recorded.
+CREATE OR REPLACE FUNCTION public.queue_scheduled_refreshes_v2()
+RETURNS integer
+LANGUAGE plpgsql
+SET search_path = public, extensions
+AS $$
+DECLARE
+  lock_acquired boolean;
+  queue_depth integer;
+  initial_queue_depth integer;
+  target_queue_depth integer;
+  batch_capacity integer := 25;
+  max_symbols_per_run integer := 100;
+  symbols_checked integer := 0;
+  queued_count integer := 0;
+  v_symbol text;
+  v_scheduled_types text[];
+  v_types_for_symbol text[];
+  v_profile_exists boolean;
+BEGIN
+  SELECT pg_try_advisory_lock(43) INTO lock_acquired;
+  IF NOT lock_acquired THEN
+    RETURN 0;
+  END IF;
+
+  BEGIN
+    IF public.is_quota_exceeded_v2() THEN
+      PERFORM pg_advisory_unlock(43);
+      RETURN 0;
+    END IF;
+
+    SELECT COALESCE(effective.max_batch_jobs, 25)
+    INTO batch_capacity
+    FROM public.get_effective_quota_usage_v2() AS effective;
+
+    batch_capacity := LEAST(GREATEST(batch_capacity, 1), 125);
+    target_queue_depth := GREATEST(batch_capacity * 2, 50);
+
+    SELECT count(*)::integer
+    INTO queue_depth
+    FROM public.api_call_queue_v2 AS queue
+    WHERE queue.status = 'pending';
+
+    initial_queue_depth := queue_depth;
+
+    IF queue_depth >= target_queue_depth THEN
+      PERFORM pg_advisory_unlock(43);
+      RETURN 0;
+    END IF;
+
+    SELECT array_agg(registry.data_type ORDER BY registry.data_type)
+    INTO v_scheduled_types
+    FROM public.data_type_registry_v2 AS registry
+    WHERE registry.refresh_strategy IN ('scheduled', 'hybrid')
+      AND registry.symbol_column IS NOT NULL;
+
+    IF COALESCE(array_length(v_scheduled_types, 1), 0) = 0 THEN
+      PERFORM pg_advisory_unlock(43);
+      RETURN 0;
+    END IF;
+
+    FOR v_symbol IN
+      SELECT listed.symbol
+      FROM public.listed_symbols AS listed
+      WHERE listed.is_active = true
+      ORDER BY listed.last_processed_at ASC NULLS FIRST, listed.symbol
+      LIMIT max_symbols_per_run
+      FOR UPDATE SKIP LOCKED
+    LOOP
+      EXIT WHEN queue_depth >= target_queue_depth;
+
+      SELECT EXISTS (
+        SELECT 1
+        FROM public.profiles AS profile
+        WHERE profile.symbol = v_symbol
+      )
+      INTO v_profile_exists;
+
+      -- Dependent tables reference profiles(symbol). Bootstrap the profile in
+      -- one pass, then consider the other types on the next round-robin pass.
+      IF v_profile_exists THEN
+        v_types_for_symbol := v_scheduled_types;
+      ELSIF 'profile' = ANY(v_scheduled_types) THEN
+        v_types_for_symbol := ARRAY['profile']::text[];
+      ELSE
+        v_types_for_symbol := ARRAY[]::text[];
+      END IF;
+
+      IF COALESCE(array_length(v_types_for_symbol, 1), 0) > 0 THEN
+        PERFORM public.check_and_queue_stale_batch_v2(
+          p_symbol := v_symbol,
+          p_data_types := v_types_for_symbol,
+          p_priority := -1
+        );
+      END IF;
+
+      UPDATE public.listed_symbols AS listed
+      SET last_processed_at = clock_timestamp()
+      WHERE listed.symbol = v_symbol;
+
+      symbols_checked := symbols_checked + 1;
+
+      SELECT count(*)::integer
+      INTO queue_depth
+      FROM public.api_call_queue_v2 AS queue
+      WHERE queue.status = 'pending';
+    END LOOP;
+
+    queued_count := GREATEST(queue_depth - initial_queue_depth, 0);
+
+    INSERT INTO public.cron_health_logs (jobname, last_run)
+    VALUES ('queue-scheduled-refreshes-v2', now())
+    ON CONFLICT (jobname) DO UPDATE
+    SET last_run = EXCLUDED.last_run;
+
+    PERFORM pg_advisory_unlock(43);
+    RETURN queued_count;
+  EXCEPTION
+    WHEN OTHERS THEN
+      PERFORM pg_advisory_unlock(43);
+      RAISE;
+  END;
+END;
+$$;
+
+COMMENT ON FUNCTION public.queue_scheduled_refreshes_v2() IS
+  'Queues TTL-stale scheduled/hybrid data across active listed symbols using bounded oldest-first round robin. It fills at most two calibrated processor batches, bootstraps profiles before FK-dependent data, checks quota first, and assigns priority -1.';
+
+-- Supabase's migration role cannot read cron.job directly. Expose only the
+-- FMP pipeline jobs needed by operational verification through a narrow
+-- security-definer surface owned by postgres.
+CREATE OR REPLACE FUNCTION public.get_fmp_pipeline_cron_state_v2()
+RETURNS TABLE (
+  jobid bigint,
+  jobname text,
+  schedule text,
+  command text,
+  active boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    job.jobid,
+    job.jobname::text,
+    job.schedule::text,
+    job.command::text,
+    job.active
+  FROM cron.job AS job
+  WHERE job.jobname IN (
+    'queue-scheduled-refreshes-v2',
+    'invoke-processor-v2'
+  )
+     OR job.jobname LIKE 'controlled-fmp-live-processing-%'
+  ORDER BY job.jobid;
+$$;
+
+ALTER FUNCTION public.get_fmp_pipeline_cron_state_v2() OWNER TO postgres;
+
+REVOKE ALL
+ON FUNCTION public.get_fmp_pipeline_cron_state_v2()
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE
+ON FUNCTION public.get_fmp_pipeline_cron_state_v2()
+TO service_role;
+
+COMMENT ON FUNCTION public.get_fmp_pipeline_cron_state_v2() IS
+  'Read-only, filtered pg_cron state for the FMP scheduler and processor paths.';
+
+-- Fail closed even when an older environment still has the original cron
+-- active. Production must first deploy the updated queue processor, record the
+-- current FMP dashboard calibration, and then activate this job explicitly.
+SELECT cron.unschedule('queue-scheduled-refreshes-v2');
+
+COMMIT;

--- a/supabase/migrations/__tests__/monofunction_migration.test.sql
+++ b/supabase/migrations/__tests__/monofunction_migration.test.sql
@@ -90,7 +90,7 @@ DECLARE
 BEGIN
   SELECT COUNT(*) INTO invalid_strategy_count
   FROM public.data_type_registry_v2
-  WHERE refresh_strategy NOT IN ('on-demand', 'scheduled');
+  WHERE refresh_strategy NOT IN ('on-demand', 'scheduled', 'hybrid');
 
   IF invalid_strategy_count > 0 THEN
     RAISE EXCEPTION 'Found % data types with invalid refresh_strategy', invalid_strategy_count;
@@ -116,4 +116,3 @@ BEGIN
 END $$;
 
 RAISE NOTICE 'All monofunction migration tests PASSED!';
-

--- a/tests/contracts/run_all_contracts.sql
+++ b/tests/contracts/run_all_contracts.sql
@@ -41,7 +41,7 @@ END $$;
 \i test_contract_8_scheduled_job_priority.sql
 
 \echo ''
-\echo 'Running Contract #9: TABLESAMPLE...'
+\echo 'Running Contract #9: Bounded scheduled round robin...'
 \i test_contract_9_tablesample.sql
 
 \echo ''
@@ -75,6 +75,10 @@ END $$;
 \echo ''
 \echo 'Running Contract #19: Successful Empty Fetch Freshness...'
 \i test_contract_19_negative_cache_freshness.sql
+
+\echo ''
+\echo 'Running Contract #20: Scheduled durable-data baseline...'
+\i test_contract_20_scheduled_refresh_baseline.sql
 
 \echo ''
 \echo '✅ All contract tests completed!'

--- a/tests/contracts/test_contract_20_scheduled_refresh_baseline.sql
+++ b/tests/contracts/test_contract_20_scheduled_refresh_baseline.sql
@@ -1,0 +1,259 @@
+-- Contract #20: Scheduled Durable-Data Baseline
+-- Compass-critical durable inputs must receive full-universe scheduled
+-- coverage. Presence may raise their priority, but quotes remain on demand.
+
+BEGIN;
+SELECT plan(18);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.data_type_registry_v2
+    WHERE data_type IN (
+      'profile',
+      'financial-statements',
+      'ratios-ttm',
+      'insider-transactions',
+      'insider-trading-statistics'
+    )
+      AND refresh_strategy = 'hybrid'
+  ),
+  5,
+  'Contract #20: all durable Compass inputs use hybrid scheduled coverage'
+);
+
+SELECT is(
+  (
+    SELECT refresh_strategy
+    FROM public.data_type_registry_v2
+    WHERE data_type = 'quote'
+  ),
+  'on-demand',
+  'Contract #20: quotes remain on demand'
+);
+
+SELECT is(
+  (
+    SELECT default_ttl_minutes
+    FROM public.data_type_registry_v2
+    WHERE data_type = 'financial-statements'
+  ),
+  10080,
+  'Contract #20: financial statements refresh weekly'
+);
+
+SELECT is(
+  (
+    SELECT default_ttl_minutes
+    FROM public.data_type_registry_v2
+    WHERE data_type = 'profile'
+  ),
+  1440,
+  'Contract #20: profiles refresh daily'
+);
+
+SELECT is(
+  (
+    SELECT default_ttl_minutes
+    FROM public.data_type_registry_v2
+    WHERE data_type = 'ratios-ttm'
+  ),
+  1440,
+  'Contract #20: ratios refresh daily'
+);
+
+SELECT is(
+  (
+    SELECT default_ttl_minutes
+    FROM public.data_type_registry_v2
+    WHERE data_type = 'insider-transactions'
+  ),
+  2880,
+  'Contract #20: insider transactions retain the 48-hour bandwidth-aware TTL'
+);
+
+SELECT is(
+  (
+    SELECT default_ttl_minutes
+    FROM public.data_type_registry_v2
+    WHERE data_type = 'insider-trading-statistics'
+  ),
+  10080,
+  'Contract #20: insider statistics refresh weekly'
+);
+
+SELECT ok(
+  (
+    SELECT pg_get_functiondef(procedure.oid)
+    FROM pg_proc AS procedure
+    JOIN pg_namespace AS namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname = 'public'
+      AND procedure.proname =
+          'check_and_queue_stale_data_from_presence_v2'
+  ) ~* 'refresh_strategy\s+IN\s+\(''on-demand'',\s*''hybrid''\)',
+  'Contract #20: presence remains a priority overlay for hybrid data'
+);
+
+SELECT ok(
+  (
+    SELECT pg_get_functiondef(procedure.oid)
+    FROM pg_proc AS procedure
+    JOIN pg_namespace AS namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname = 'public'
+      AND procedure.proname = 'queue_scheduled_refreshes_v2'
+  ) ~* 'refresh_strategy\s+IN\s+\(''scheduled'',\s*''hybrid''\)',
+  'Contract #20: scheduler covers scheduled and hybrid data'
+);
+
+SELECT ok(
+  (
+    SELECT pg_get_functiondef(procedure.oid)
+    FROM pg_proc AS procedure
+    JOIN pg_namespace AS namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname = 'public'
+      AND procedure.proname = 'queue_scheduled_refreshes_v2'
+  ) ~* 'v_profile_exists'
+  AND (
+    SELECT pg_get_functiondef(procedure.oid)
+    FROM pg_proc AS procedure
+    JOIN pg_namespace AS namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname = 'public'
+      AND procedure.proname = 'queue_scheduled_refreshes_v2'
+  ) ~* 'ARRAY\[''profile''\]',
+  'Contract #20: scheduler bootstraps profiles before FK-dependent data'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc AS procedure
+    JOIN pg_namespace AS namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname = 'public'
+      AND procedure.proname = 'get_fmp_pipeline_cron_state_v2'
+      AND procedure.prosecdef
+  ),
+  'Contract #20: filtered cron status is exposed through SECURITY DEFINER'
+);
+
+SELECT ok(
+  has_function_privilege(
+    'service_role',
+    'public.get_fmp_pipeline_cron_state_v2()',
+    'EXECUTE'
+  )
+  AND NOT has_function_privilege(
+    'anon',
+    'public.get_fmp_pipeline_cron_state_v2()',
+    'EXECUTE'
+  )
+  AND NOT has_function_privilege(
+    'authenticated',
+    'public.get_fmp_pipeline_cron_state_v2()',
+    'EXECUTE'
+  ),
+  'Contract #20: cron status surface is restricted to operations'
+);
+
+UPDATE public.listed_symbols
+SET is_active = false;
+
+DELETE FROM public.api_call_queue_v2
+WHERE status IN ('pending', 'processing');
+
+INSERT INTO public.listed_symbols (
+  symbol,
+  is_active,
+  last_processed_at
+)
+VALUES
+  ('SCHED_NOPROFILE', true, NULL),
+  ('SCHED_WITHPROFILE', true, NULL)
+ON CONFLICT (symbol) DO UPDATE
+SET
+  is_active = EXCLUDED.is_active,
+  last_processed_at = EXCLUDED.last_processed_at;
+
+INSERT INTO public.profiles (
+  symbol,
+  company_name,
+  modified_at
+)
+VALUES (
+  'SCHED_WITHPROFILE',
+  'Scheduler Fixture',
+  now()
+)
+ON CONFLICT (symbol) DO UPDATE
+SET
+  company_name = EXCLUDED.company_name,
+  modified_at = EXCLUDED.modified_at;
+
+SELECT is(
+  public.queue_scheduled_refreshes_v2(),
+  5,
+  'Contract #20: fixture queues exactly the five stale durable inputs'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.api_call_queue_v2
+    WHERE symbol = 'SCHED_NOPROFILE'
+      AND status = 'pending'
+  ),
+  1,
+  'Contract #20: a missing profile queues only the profile bootstrap'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.api_call_queue_v2
+    WHERE symbol = 'SCHED_WITHPROFILE'
+      AND status = 'pending'
+  ),
+  4,
+  'Contract #20: an existing profile unlocks the four stale dependent inputs'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.api_call_queue_v2
+    WHERE data_type = 'quote'
+      AND status = 'pending'
+  ),
+  0,
+  'Contract #20: the full-universe scheduler never queues quotes'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.api_call_queue_v2
+    WHERE symbol IN ('SCHED_NOPROFILE', 'SCHED_WITHPROFILE')
+      AND status = 'pending'
+      AND priority = -1
+  ),
+  5,
+  'Contract #20: every scheduled fixture job stays below demand priority'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.listed_symbols
+    WHERE symbol IN ('SCHED_NOPROFILE', 'SCHED_WITHPROFILE')
+      AND last_processed_at IS NOT NULL
+  ),
+  2,
+  'Contract #20: round robin advances every checked symbol'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/contracts/test_contract_9_tablesample.sql
+++ b/tests/contracts/test_contract_9_tablesample.sql
@@ -1,15 +1,18 @@
--- Contract #9: Scheduled Job Performance (TABLESAMPLE)
--- Test: queue_scheduled_refreshes_v2 must use TABLESAMPLE to avoid materializing massive CROSS JOINs
+-- Contract #9: Bounded Scheduled Job Performance
+-- Test: queue_scheduled_refreshes_v2 must use a bounded oldest-first scan and
+-- a calibrated queue-depth target.
 --
--- Why: At scale (50k symbols * 5 types = 250k rows), full CROSS JOIN is a performance bomb.
--- TABLESAMPLE randomly samples symbols, dramatically reducing query cost and preventing "Day 365" performance failure.
+-- Why: TABLESAMPLE avoided a full cross join but could repeatedly miss symbols.
+-- A partial index plus LIMIT gives deterministic full-universe coverage without
+-- materializing a symbols × data-types cross join.
 --
 -- What NOT to do:
--- - ❌ Remove TABLESAMPLE to "process all symbols"
--- - ❌ Use full CROSS JOIN without sampling (will fail at scale)
+-- - Use a full CROSS JOIN across symbols and data types
+-- - Scan the entire symbol universe in one cron invocation
+-- - Recreate an unbounded pending backlog
 
 BEGIN;
-SELECT plan(2);
+SELECT plan(4);
 
 -- Test 1: Function exists
 SELECT ok(
@@ -23,8 +26,7 @@ SELECT ok(
   'Contract #9: queue_scheduled_refreshes_v2 function exists'
 );
 
--- Test 2: Function definition contains TABLESAMPLE
--- Must use TABLESAMPLE SYSTEM (or similar) to sample symbols
+-- Test 2: deterministic round robin is bounded
 SELECT ok(
   EXISTS (
     SELECT 1
@@ -32,11 +34,36 @@ SELECT ok(
     JOIN pg_namespace n ON p.pronamespace = n.oid
     WHERE n.nspname = 'public'
       AND p.proname = 'queue_scheduled_refreshes_v2'
-      AND pg_get_functiondef(p.oid) ~* 'TABLESAMPLE\s+SYSTEM'
+      AND pg_get_functiondef(p.oid)
+          ~* 'ORDER BY\s+listed\.last_processed_at\s+ASC\s+NULLS\s+FIRST'
+      AND pg_get_functiondef(p.oid) ~* 'LIMIT\s+max_symbols_per_run'
   ),
-  'Contract #9: queue_scheduled_refreshes_v2 uses TABLESAMPLE to prevent Day 365 performance failure'
+  'Contract #9: scheduler uses bounded oldest-first round robin'
+);
+
+-- Test 3: queue growth is tied to the calibrated processor batch
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public'
+      AND p.proname = 'queue_scheduled_refreshes_v2'
+      AND pg_get_functiondef(p.oid)
+          ~* 'target_queue_depth\s*:=\s*GREATEST\(batch_capacity\s*\*\s*2,\s*50\)'
+      AND pg_get_functiondef(p.oid)
+          ~* 'queue_depth\s*>=\s*target_queue_depth'
+  ),
+  'Contract #9: scheduler bounds pending work to a calibrated two-batch buffer'
+);
+
+-- Test 4: the partial index supports the scheduling order
+SELECT has_index(
+  'public',
+  'listed_symbols',
+  'idx_listed_symbols_active_last_processed',
+  'Contract #9: active-symbol round robin has a supporting index'
 );
 
 SELECT * FROM finish();
 ROLLBACK;
-


### PR DESCRIPTION
Key changes:

- Scheduled full-universe refresh for durable Compass inputs.
- Quotes remain on demand.
- Bounded two-batch queue prevents backlog explosions.
- Profiles bootstrap before FK-dependent data.
- Valid empty responses no longer create corrupt sentinel records.
- Deployment leaves scheduling paused until explicitly activated.