### PR TITLE
Log financial source timestamp regressions

### DIFF
--- a/supabase/functions/__tests__/financial-source-regression.test.ts
+++ b/supabase/functions/__tests__/financial-source-regression.test.ts
@@ -1,0 +1,221 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  recordFinancialSourceRegression,
+  resolveFinancialSourceRegression,
+} from "../lib/financial-source-regression.ts";
+import type { QueueJob } from "../lib/types.ts";
+
+const job: QueueJob = {
+  id: "00000000-0000-4000-8000-000000000001",
+  symbol: "NVA",
+  data_type: "financial-statements",
+  status: "processing",
+  priority: -1,
+  retry_count: 0,
+  max_retries: 3,
+  created_at: "2026-07-31T11:00:00Z",
+  estimated_data_size_bytes: 500000,
+  job_metadata: {},
+};
+
+Deno.test("records a financial source regression with stable issue identity", async () => {
+  const calls: Array<{
+    name: string;
+    args: Record<string, unknown>;
+  }> = [];
+  const supabase = {
+    rpc: (
+      name: string,
+      args: Record<string, unknown>,
+    ) => {
+      calls.push({ name, args });
+      return Promise.resolve({ error: null });
+    },
+  } as unknown as SupabaseClient;
+
+  const message = await recordFinancialSourceRegression(
+    supabase,
+    job,
+    "2025-06-30 00:00:00",
+    "2025-09-19T16:00:54+00:00",
+    600000,
+  );
+
+  assertStringIncludes(message, "Stale source timestamp");
+  assertStringIncludes(message, "Stored data was preserved");
+  assertEquals(calls, [{
+    name: "record_data_quality_issue_v2",
+    args: {
+      p_symbol: "NVA",
+      p_provider: "fmp",
+      p_endpoint: "financial-statements",
+      p_check_code: "source_timestamp_regression",
+      p_severity: "warning",
+      p_message:
+        "FMP returned financial statements older than the newest stored filing; the stored data was preserved.",
+      p_evidence: {
+        incoming_max_accepted_date: "2025-06-30 00:00:00",
+        stored_max_accepted_date: "2025-09-19T16:00:54+00:00",
+        response_size_bytes: 600000,
+        queue_job_id: "00000000-0000-4000-8000-000000000001",
+        retry_count: 0,
+        max_retries: 3,
+      },
+      p_field_name: "accepted_date",
+      p_source_date: null,
+      p_source_period: null,
+      p_source_reference: "accepted-date-regression",
+    },
+  }]);
+});
+
+Deno.test("does not discard a regression when issue persistence fails", async () => {
+  const supabase = {
+    rpc: () =>
+      Promise.resolve({
+        error: { message: "database unavailable" },
+      }),
+  } as unknown as SupabaseClient;
+
+  await assertRejects(
+    () =>
+      recordFinancialSourceRegression(
+        supabase,
+        job,
+        "2025-06-30 00:00:00",
+        "2025-09-19T16:00:54+00:00",
+        600000,
+      ),
+    Error,
+    "Failed to record financial source regression",
+  );
+});
+
+Deno.test("resolves only the stable source-regression fingerprint", async () => {
+  const calls: Array<{
+    name: string;
+    args: Record<string, unknown>;
+  }> = [];
+  const supabase = {
+    rpc: (
+      name: string,
+      args: Record<string, unknown>,
+    ) => {
+      calls.push({ name, args });
+      return Promise.resolve({ error: null });
+    },
+  } as unknown as SupabaseClient;
+
+  assertEquals(
+    await resolveFinancialSourceRegression(supabase, "NVA"),
+    true,
+  );
+  assertEquals(calls, [{
+    name: "resolve_data_quality_issue_v2",
+    args: {
+      p_symbol: "NVA",
+      p_provider: "fmp",
+      p_endpoint: "financial-statements",
+      p_check_code: "source_timestamp_regression",
+      p_field_name: "accepted_date",
+      p_source_date: null,
+      p_source_period: null,
+      p_source_reference: "accepted-date-regression",
+    },
+  }]);
+});
+
+Deno.test("financial handler records regressions without advancing freshness", async () => {
+  const originalFetch = globalThis.fetch;
+  const rpcCalls: Array<{
+    name: string;
+    args: Record<string, unknown>;
+  }> = [];
+  const baseStatement = {
+    date: "2025-06-30",
+    symbol: "NVA",
+    reportedCurrency: "USD",
+    cik: "0000000001",
+    filingDate: "2025-06-30",
+    acceptedDate: "2025-06-30 00:00:00",
+    fiscalYear: "2025",
+    period: "FY",
+  };
+
+  Deno.env.set("FMP_API_KEY", "source-regression-test-key");
+  const { fetchFinancialStatementsLogic } = await import(
+    "../lib/fetch-fmp-financial-statements.ts?source-regression-test"
+  );
+
+  try {
+    globalThis.fetch = () =>
+      Promise.resolve(
+        new Response(JSON.stringify([baseStatement]), {
+          status: 200,
+          headers: { "Content-Length": "200000" },
+        }),
+      );
+
+    const supabase = {
+      rpc: (
+        name: string,
+        args: Record<string, unknown>,
+      ) => {
+        rpcCalls.push({ name, args });
+        return Promise.resolve({ error: null });
+      },
+      from: (table: string) => {
+        if (table === "data_type_registry_v2") {
+          const chain = {
+            select: () => chain,
+            eq: () => chain,
+            single: () =>
+              Promise.resolve({
+                data: { source_timestamp_column: "accepted_date" },
+                error: null,
+              }),
+          };
+          return chain;
+        }
+
+        if (table === "financial_statements") {
+          const chain = {
+            select: () => chain,
+            eq: () => chain,
+            not: () => chain,
+            order: () => chain,
+            limit: () => chain,
+            maybeSingle: () =>
+              Promise.resolve({
+                data: { accepted_date: "2025-09-19T16:00:54+00:00" },
+                error: null,
+              }),
+            upsert: () => {
+              throw new Error("regressed data must not be upserted");
+            },
+          };
+          return chain;
+        }
+
+        throw new Error(`Unexpected table access: ${table}`);
+      },
+    } as unknown as SupabaseClient;
+
+    const result = await fetchFinancialStatementsLogic(job, supabase);
+
+    assertEquals(result.success, false);
+    assertEquals(result.dataSizeBytes, 600000);
+    assertStringIncludes(result.error ?? "", "Stale source timestamp");
+    assertEquals(
+      rpcCalls.map((call) => call.name),
+      ["record_data_quality_issue_v2"],
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/supabase/functions/lib/fetch-fmp-financial-statements.ts
+++ b/supabase/functions/lib/fetch-fmp-financial-statements.ts
@@ -13,6 +13,10 @@ import type {
   FmpIncomeStatementEntry,
   FmpStatementEntryBase,
 } from "../fetch-fmp-financial-statements/types.ts";
+import {
+  recordFinancialSourceRegression,
+  resolveFinancialSourceRegression,
+} from "./financial-source-regression.ts";
 import { recordDataFetchFreshness } from "./record-data-fetch-freshness.ts";
 
 const FMP_API_KEY = Deno.env.get("FMP_API_KEY");
@@ -266,14 +270,22 @@ export async function fetchFinancialStatementsLogic(
             // The API is returning older filings (caching bug, stale cache, etc.)
             // We must reject this to prevent "data laundering"
             if (newSourceTimestamp < oldSourceTimestamp) {
-              // Do not advance freshness when the source actually regresses.
-              // Returning a failure preserves the measured bandwidth and lets
-              // the queue's normal retry/backoff policy handle the anomaly.
+              // Persist the deterministic provider anomaly before returning.
+              // "Stale source timestamp" intentionally matches the queue's
+              // immediate-failure rule, avoiding wasteful retries while
+              // successful freshness remains unchanged.
+              const regressionMessage = await recordFinancialSourceRegression(
+                supabase,
+                job,
+                maxNewAcceptedDate,
+                existingData.accepted_date,
+                totalDataSizeBytes,
+              );
+
               return {
                 success: false,
                 dataSizeBytes: totalDataSizeBytes,
-                error:
-                  `FMP returned older financial statements for ${job.symbol} (source timestamp: ${maxNewAcceptedDate} vs existing: ${existingData.accepted_date}).`,
+                error: regressionMessage,
               };
             }
             // Equal source timestamps are normal between filings. The fetch is
@@ -301,6 +313,11 @@ export async function fetchFinancialStatementsLogic(
         true,
         totalDataSizeBytes,
       );
+
+      // A validated response at least as new as the stored source clears only
+      // this specific regression finding. Other financial-data findings are
+      // deliberately left untouched.
+      await resolveFinancialSourceRegression(supabase, job.symbol);
     } else {
       console.warn(
         `[fetchFinancialStatementsLogic] No consolidated statement data to upsert for ${job.symbol}`,

--- a/supabase/functions/lib/financial-source-regression.ts
+++ b/supabase/functions/lib/financial-source-regression.ts
@@ -1,0 +1,85 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { QueueJob } from "./types.ts";
+
+const PROVIDER = "fmp";
+const ENDPOINT = "financial-statements";
+const CHECK_CODE = "source_timestamp_regression";
+const FIELD_NAME = "accepted_date";
+const SOURCE_REFERENCE = "accepted-date-regression";
+
+function queueFailureMessage(
+  symbol: string,
+  incomingTimestamp: string,
+  storedTimestamp: string,
+): string {
+  return `Stale source timestamp: FMP returned older financial statements for ${symbol} (source timestamp: ${incomingTimestamp} vs existing: ${storedTimestamp}). Stored data was preserved.`;
+}
+
+export async function recordFinancialSourceRegression(
+  supabase: SupabaseClient,
+  job: QueueJob,
+  incomingTimestamp: string,
+  storedTimestamp: string,
+  responseSizeBytes: number,
+): Promise<string> {
+  const message = queueFailureMessage(
+    job.symbol,
+    incomingTimestamp,
+    storedTimestamp,
+  );
+
+  const { error } = await supabase.rpc("record_data_quality_issue_v2", {
+    p_symbol: job.symbol,
+    p_provider: PROVIDER,
+    p_endpoint: ENDPOINT,
+    p_check_code: CHECK_CODE,
+    p_severity: "warning",
+    p_message:
+      "FMP returned financial statements older than the newest stored filing; the stored data was preserved.",
+    p_evidence: {
+      incoming_max_accepted_date: incomingTimestamp,
+      stored_max_accepted_date: storedTimestamp,
+      response_size_bytes: responseSizeBytes,
+      queue_job_id: job.id,
+      retry_count: job.retry_count,
+      max_retries: job.max_retries,
+    },
+    p_field_name: FIELD_NAME,
+    p_source_date: null,
+    p_source_period: null,
+    p_source_reference: SOURCE_REFERENCE,
+  });
+
+  if (error) {
+    throw new Error(
+      `Failed to record financial source regression for ${job.symbol}: ${error.message}`,
+    );
+  }
+
+  return message;
+}
+
+export async function resolveFinancialSourceRegression(
+  supabase: SupabaseClient,
+  symbol: string,
+): Promise<boolean> {
+  const { error } = await supabase.rpc("resolve_data_quality_issue_v2", {
+    p_symbol: symbol,
+    p_provider: PROVIDER,
+    p_endpoint: ENDPOINT,
+    p_check_code: CHECK_CODE,
+    p_field_name: FIELD_NAME,
+    p_source_date: null,
+    p_source_period: null,
+    p_source_reference: SOURCE_REFERENCE,
+  });
+
+  if (error) {
+    console.error(
+      `[data-quality] Failed to resolve financial source regression for ${symbol}: ${error.message}`,
+    );
+    return false;
+  }
+
+  return true;
+}

--- a/supabase/migrations/20260731010000_record_financial_source_regressions.sql
+++ b/supabase/migrations/20260731010000_record_financial_source_regressions.sql
@@ -1,0 +1,378 @@
+-- Persist individual deterministic provider findings without resolving other
+-- checks that share the same provider/endpoint scope.
+
+CREATE OR REPLACE FUNCTION public.record_data_quality_issue_v2(
+  p_symbol text,
+  p_provider text,
+  p_endpoint text,
+  p_check_code text,
+  p_severity text,
+  p_message text,
+  p_evidence jsonb DEFAULT '{}'::jsonb,
+  p_field_name text DEFAULT NULL,
+  p_source_date date DEFAULT NULL,
+  p_source_period text DEFAULT NULL,
+  p_source_reference text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_symbol text := pg_catalog.upper(pg_catalog.btrim(p_symbol));
+  v_provider text := pg_catalog.lower(pg_catalog.btrim(p_provider));
+  v_endpoint text := pg_catalog.lower(pg_catalog.btrim(p_endpoint));
+  v_check_code text := pg_catalog.btrim(p_check_code);
+  v_field_name text := NULLIF(pg_catalog.btrim(p_field_name), '');
+  v_source_period text := NULLIF(
+    pg_catalog.btrim(p_source_period),
+    ''
+  );
+  v_source_reference text := NULLIF(
+    pg_catalog.btrim(p_source_reference),
+    ''
+  );
+  v_fingerprint text;
+  v_issue_id uuid;
+BEGIN
+  IF v_symbol IS NULL OR v_symbol = '' THEN
+    RAISE EXCEPTION 'symbol must not be empty';
+  END IF;
+  IF v_provider IS NULL OR v_provider = '' THEN
+    RAISE EXCEPTION 'provider must not be empty';
+  END IF;
+  IF v_endpoint IS NULL OR v_endpoint = '' THEN
+    RAISE EXCEPTION 'endpoint must not be empty';
+  END IF;
+  IF v_check_code IS NULL OR v_check_code = '' THEN
+    RAISE EXCEPTION 'check code must not be empty';
+  END IF;
+  IF p_message IS NULL OR pg_catalog.btrim(p_message) = '' THEN
+    RAISE EXCEPTION 'message must not be empty';
+  END IF;
+  IF p_severity IS NULL
+     OR p_severity NOT IN ('info', 'warning', 'critical')
+  THEN
+    RAISE EXCEPTION 'invalid severity: %', p_severity;
+  END IF;
+  IF p_evidence IS NULL OR pg_catalog.jsonb_typeof(p_evidence) <> 'object' THEN
+    RAISE EXCEPTION 'evidence must be a JSON object';
+  END IF;
+
+  v_fingerprint := pg_catalog.concat_ws(
+    '|',
+    v_provider,
+    v_endpoint,
+    v_symbol,
+    v_check_code,
+    COALESCE(v_field_name, ''),
+    COALESCE(p_source_date::text, ''),
+    COALESCE(v_source_period, ''),
+    COALESCE(v_source_reference, '')
+  );
+
+  INSERT INTO public.data_quality_issues (
+    fingerprint,
+    symbol,
+    provider,
+    endpoint,
+    check_code,
+    field_name,
+    severity,
+    status,
+    message,
+    evidence,
+    source_date,
+    source_period,
+    source_reference,
+    detected_at,
+    last_seen_at,
+    resolved_at,
+    occurrence_count
+  )
+  VALUES (
+    v_fingerprint,
+    v_symbol,
+    v_provider,
+    v_endpoint,
+    v_check_code,
+    v_field_name,
+    p_severity,
+    'open',
+    p_message,
+    p_evidence,
+    p_source_date,
+    v_source_period,
+    v_source_reference,
+    pg_catalog.now(),
+    pg_catalog.now(),
+    NULL,
+    1
+  )
+  ON CONFLICT (fingerprint) DO UPDATE
+  SET
+    severity = EXCLUDED.severity,
+    status = 'open',
+    message = EXCLUDED.message,
+    evidence = EXCLUDED.evidence,
+    last_seen_at = pg_catalog.now(),
+    resolved_at = NULL,
+    occurrence_count = public.data_quality_issues.occurrence_count + 1
+  RETURNING id INTO v_issue_id;
+
+  RETURN v_issue_id;
+END;
+$$;
+
+ALTER FUNCTION public.record_data_quality_issue_v2(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  jsonb,
+  text,
+  date,
+  text,
+  text
+) OWNER TO postgres;
+
+REVOKE ALL
+ON FUNCTION public.record_data_quality_issue_v2(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  jsonb,
+  text,
+  date,
+  text,
+  text
+)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE
+ON FUNCTION public.record_data_quality_issue_v2(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  jsonb,
+  text,
+  date,
+  text,
+  text
+)
+TO service_role;
+
+COMMENT ON FUNCTION public.record_data_quality_issue_v2(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  jsonb,
+  text,
+  date,
+  text,
+  text
+) IS
+  'Atomically opens or refreshes one deterministic provider-data issue without resolving unrelated findings.';
+
+CREATE OR REPLACE FUNCTION public.resolve_data_quality_issue_v2(
+  p_symbol text,
+  p_provider text,
+  p_endpoint text,
+  p_check_code text,
+  p_field_name text DEFAULT NULL,
+  p_source_date date DEFAULT NULL,
+  p_source_period text DEFAULT NULL,
+  p_source_reference text DEFAULT NULL
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_fingerprint text := pg_catalog.concat_ws(
+    '|',
+    pg_catalog.lower(pg_catalog.btrim(p_provider)),
+    pg_catalog.lower(pg_catalog.btrim(p_endpoint)),
+    pg_catalog.upper(pg_catalog.btrim(p_symbol)),
+    pg_catalog.btrim(p_check_code),
+    COALESCE(
+      NULLIF(pg_catalog.btrim(p_field_name), ''),
+      ''
+    ),
+    COALESCE(p_source_date::text, ''),
+    COALESCE(
+      NULLIF(pg_catalog.btrim(p_source_period), ''),
+      ''
+    ),
+    COALESCE(
+      NULLIF(pg_catalog.btrim(p_source_reference), ''),
+      ''
+    )
+  );
+BEGIN
+  UPDATE public.data_quality_issues AS issue
+  SET
+    status = 'resolved',
+    resolved_at = pg_catalog.now()
+  WHERE issue.fingerprint = v_fingerprint
+    AND issue.status = 'open';
+
+  RETURN FOUND;
+END;
+$$;
+
+ALTER FUNCTION public.resolve_data_quality_issue_v2(
+  text,
+  text,
+  text,
+  text,
+  text,
+  date,
+  text,
+  text
+) OWNER TO postgres;
+
+REVOKE ALL
+ON FUNCTION public.resolve_data_quality_issue_v2(
+  text,
+  text,
+  text,
+  text,
+  text,
+  date,
+  text,
+  text
+)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE
+ON FUNCTION public.resolve_data_quality_issue_v2(
+  text,
+  text,
+  text,
+  text,
+  text,
+  date,
+  text,
+  text
+)
+TO service_role;
+
+COMMENT ON FUNCTION public.resolve_data_quality_issue_v2(
+  text,
+  text,
+  text,
+  text,
+  text,
+  date,
+  text,
+  text
+) IS
+  'Resolves one deterministic provider-data issue by its stable fingerprint.';
+
+-- Backfill source regressions that reached the failed queue before this
+-- producer was deployed. Keeping the fingerprint independent of observed
+-- timestamps gives each symbol one durable issue whose evidence can evolve.
+WITH regression_jobs AS (
+  SELECT DISTINCT ON (queue.symbol)
+    queue.symbol,
+    queue.id,
+    queue.created_at,
+    queue.processed_at,
+    queue.retry_count,
+    queue.error_message,
+    pg_catalog.substring(
+      queue.error_message,
+      'source timestamp: (.+) vs existing:'
+    ) AS incoming_timestamp,
+    pg_catalog.substring(
+      queue.error_message,
+      'vs existing: (.+)\)\.?$'
+    ) AS stored_timestamp
+  FROM public.api_call_queue_v2 AS queue
+  WHERE queue.data_type = 'financial-statements'
+    AND queue.status = 'failed'
+    AND queue.error_message
+      ILIKE 'FMP returned older financial statements for %'
+  ORDER BY
+    queue.symbol,
+    COALESCE(queue.processed_at, queue.created_at) DESC,
+    queue.id
+)
+INSERT INTO public.data_quality_issues (
+  fingerprint,
+  symbol,
+  provider,
+  endpoint,
+  check_code,
+  field_name,
+  severity,
+  status,
+  message,
+  evidence,
+  source_reference,
+  detected_at,
+  last_seen_at,
+  occurrence_count
+)
+SELECT
+  pg_catalog.concat_ws(
+    '|',
+    'fmp',
+    'financial-statements',
+    pg_catalog.upper(pg_catalog.btrim(regression.symbol)),
+    'source_timestamp_regression',
+    'accepted_date',
+    '',
+    '',
+    'accepted-date-regression'
+  ),
+  pg_catalog.upper(pg_catalog.btrim(regression.symbol)),
+  'fmp',
+  'financial-statements',
+  'source_timestamp_regression',
+  'accepted_date',
+  'warning',
+  'open',
+  'FMP returned financial statements older than the newest stored filing; the stored data was preserved.',
+  pg_catalog.jsonb_build_object(
+    'incoming_max_accepted_date', regression.incoming_timestamp,
+    'stored_max_accepted_date', regression.stored_timestamp,
+    'queue_job_id', regression.id,
+    'queue_error', regression.error_message,
+    'attempt_count', regression.retry_count + 1,
+    'backfilled', true
+  ),
+  'accepted-date-regression',
+  regression.created_at,
+  COALESCE(regression.processed_at, regression.created_at),
+  GREATEST(regression.retry_count + 1, 1)
+FROM regression_jobs AS regression
+ON CONFLICT (fingerprint) DO UPDATE
+SET
+  status = 'open',
+  severity = EXCLUDED.severity,
+  message = EXCLUDED.message,
+  evidence = EXCLUDED.evidence,
+  last_seen_at = GREATEST(
+    public.data_quality_issues.last_seen_at,
+    EXCLUDED.last_seen_at
+  ),
+  resolved_at = NULL,
+  occurrence_count = GREATEST(
+    public.data_quality_issues.occurrence_count,
+    EXCLUDED.occurrence_count
+  );

--- a/tests/contracts/run_all_contracts.sql
+++ b/tests/contracts/run_all_contracts.sql
@@ -81,4 +81,8 @@ END $$;
 \i test_contract_20_scheduled_refresh_baseline.sql
 
 \echo ''
+\echo 'Running Contract #21: Financial source timestamp regressions...'
+\i test_contract_21_financial_source_regression.sql
+
+\echo ''
 \echo '✅ All contract tests completed!'

--- a/tests/contracts/test_contract_21_financial_source_regression.sql
+++ b/tests/contracts/test_contract_21_financial_source_regression.sql
@@ -1,0 +1,248 @@
+-- Contract #21: Financial Source Timestamp Regressions
+-- Deterministic upstream regressions are durable quality issues, preserve
+-- successful freshness, and fail once without consuming retry bandwidth.
+
+BEGIN;
+SELECT plan(14);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc AS procedure
+    JOIN pg_namespace AS namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname = 'public'
+      AND procedure.proname = 'record_data_quality_issue_v2'
+      AND procedure.prosecdef
+  ),
+  'Contract #21: individual issue recorder is SECURITY DEFINER'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc AS procedure
+    JOIN pg_namespace AS namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname = 'public'
+      AND procedure.proname = 'resolve_data_quality_issue_v2'
+      AND procedure.prosecdef
+  ),
+  'Contract #21: individual issue resolver is SECURITY DEFINER'
+);
+
+SELECT ok(
+  has_function_privilege(
+    'service_role',
+    'public.record_data_quality_issue_v2(text,text,text,text,text,text,jsonb,text,date,text,text)',
+    'EXECUTE'
+  )
+  AND NOT has_function_privilege(
+    'anon',
+    'public.record_data_quality_issue_v2(text,text,text,text,text,text,jsonb,text,date,text,text)',
+    'EXECUTE'
+  )
+  AND NOT has_function_privilege(
+    'authenticated',
+    'public.record_data_quality_issue_v2(text,text,text,text,text,text,jsonb,text,date,text,text)',
+    'EXECUTE'
+  ),
+  'Contract #21: only service code can record individual issues'
+);
+
+SELECT ok(
+  has_function_privilege(
+    'service_role',
+    'public.resolve_data_quality_issue_v2(text,text,text,text,text,date,text,text)',
+    'EXECUTE'
+  )
+  AND NOT has_function_privilege(
+    'anon',
+    'public.resolve_data_quality_issue_v2(text,text,text,text,text,date,text,text)',
+    'EXECUTE'
+  )
+  AND NOT has_function_privilege(
+    'authenticated',
+    'public.resolve_data_quality_issue_v2(text,text,text,text,text,date,text,text)',
+    'EXECUTE'
+  ),
+  'Contract #21: only service code can resolve individual issues'
+);
+
+SELECT lives_ok(
+  $$
+    SELECT public.record_data_quality_issue_v2(
+      p_symbol := 'dqtest',
+      p_provider := 'FMP',
+      p_endpoint := 'financial-statements',
+      p_check_code := 'source_timestamp_regression',
+      p_severity := 'warning',
+      p_message := 'Provider source timestamp regressed.',
+      p_evidence := jsonb_build_object(
+        'incoming_max_accepted_date', '2025-06-30 00:00:00',
+        'stored_max_accepted_date', '2025-09-19T16:00:54+00:00'
+      ),
+      p_field_name := 'accepted_date',
+      p_source_reference := 'accepted-date-regression'
+    )
+  $$,
+  'Contract #21: a source regression can be recorded'
+);
+
+SELECT is(
+  (
+    SELECT concat_ws('|', symbol, check_code, severity, status)
+    FROM public.data_quality_issues
+    WHERE symbol = 'DQTEST'
+      AND check_code = 'source_timestamp_regression'
+  ),
+  'DQTEST|source_timestamp_regression|warning|open',
+  'Contract #21: the durable issue is normalized, open, and warning severity'
+);
+
+SELECT lives_ok(
+  $$
+    SELECT public.record_data_quality_issue_v2(
+      p_symbol := 'DQTEST',
+      p_provider := 'fmp',
+      p_endpoint := 'financial-statements',
+      p_check_code := 'source_timestamp_regression',
+      p_severity := 'warning',
+      p_message := 'Provider source timestamp regressed again.',
+      p_evidence := '{}'::jsonb,
+      p_field_name := 'accepted_date',
+      p_source_reference := 'accepted-date-regression'
+    )
+  $$,
+  'Contract #21: a repeated observation updates the same issue'
+);
+
+SELECT is(
+  (
+    SELECT occurrence_count
+    FROM public.data_quality_issues
+    WHERE symbol = 'DQTEST'
+      AND check_code = 'source_timestamp_regression'
+  ),
+  2,
+  'Contract #21: repeated observations increment occurrence count'
+);
+
+SELECT lives_ok(
+  $$
+    SELECT public.record_data_quality_issue_v2(
+      p_symbol := 'DQTEST',
+      p_provider := 'fmp',
+      p_endpoint := 'financial-statements',
+      p_check_code := 'balance_sheet_reconciliation',
+      p_severity := 'warning',
+      p_message := 'Unrelated reconciliation finding.',
+      p_evidence := '{}'::jsonb,
+      p_field_name := 'total_assets',
+      p_source_reference := 'accounting-equation'
+    )
+  $$,
+  'Contract #21: an unrelated financial finding can coexist'
+);
+
+INSERT INTO public.api_call_queue_v2 (
+  symbol,
+  data_type,
+  status,
+  priority,
+  retry_count,
+  max_retries,
+  estimated_data_size_bytes,
+  processed_at
+)
+VALUES (
+  'DQTEST',
+  'financial-statements',
+  'processing',
+  -1,
+  0,
+  3,
+  600000,
+  now()
+);
+
+SELECT lives_ok(
+  $$
+    SELECT public.fail_queue_job_v2(
+      (
+        SELECT id
+        FROM public.api_call_queue_v2
+        WHERE symbol = 'DQTEST'
+          AND data_type = 'financial-statements'
+          AND status = 'processing'
+        ORDER BY created_at DESC
+        LIMIT 1
+      ),
+      'Stale source timestamp: provider returned older data.',
+      600000
+    )
+  $$,
+  'Contract #21: source-regression failure is accepted by queue management'
+);
+
+SELECT is(
+  (
+    SELECT status
+    FROM public.api_call_queue_v2
+    WHERE symbol = 'DQTEST'
+      AND data_type = 'financial-statements'
+    ORDER BY created_at DESC
+    LIMIT 1
+  ),
+  'failed',
+  'Contract #21: deterministic source regression fails immediately'
+);
+
+SELECT is(
+  (
+    SELECT retry_count
+    FROM public.api_call_queue_v2
+    WHERE symbol = 'DQTEST'
+      AND data_type = 'financial-statements'
+    ORDER BY created_at DESC
+    LIMIT 1
+  ),
+  0,
+  'Contract #21: deterministic source regression consumes no retry'
+);
+
+SELECT is(
+  public.resolve_data_quality_issue_v2(
+    p_symbol := 'DQTEST',
+    p_provider := 'fmp',
+    p_endpoint := 'financial-statements',
+    p_check_code := 'source_timestamp_regression',
+    p_field_name := 'accepted_date',
+    p_source_reference := 'accepted-date-regression'
+  ),
+  true,
+  'Contract #21: a later valid response resolves the regression fingerprint'
+);
+
+SELECT is(
+  (
+    SELECT concat_ws(
+      '|',
+      max(status) FILTER (
+        WHERE check_code = 'source_timestamp_regression'
+      ),
+      max(status) FILTER (
+        WHERE check_code = 'balance_sheet_reconciliation'
+      )
+    )
+    FROM public.data_quality_issues
+    WHERE symbol = 'DQTEST'
+      AND provider = 'fmp'
+      AND endpoint = 'financial-statements'
+  ),
+  'resolved|open',
+  'Contract #21: resolving the regression leaves unrelated findings open'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
- Backfills NVA into data_quality_issues as an open warning with four historical attempts.
- Logs future source-timestamp regressions before failing the job.
- Preserves newer stored data and does not advance freshness.
- Fails deterministic regressions immediately without three retries.
- Resolves only the matching regression after FMP returns current data.