### PR TITLE
Prevent scheduled refresh failure churn

### DIFF
--- a/supabase/migrations/20260731020000_add_refresh_failure_cooldowns.sql
+++ b/supabase/migrations/20260731020000_add_refresh_failure_cooldowns.sql
@@ -1,0 +1,352 @@
+-- Prevent terminal failures from being recreated on every scheduled
+-- round-robin pass. Failure cooldown is deliberately independent from
+-- successful fetch freshness: errors never make stale data look fresh.
+
+CREATE TABLE public.refresh_failure_cooldowns_v2 (
+  symbol text NOT NULL,
+  data_type text NOT NULL
+    REFERENCES public.data_type_registry_v2(data_type)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE,
+  consecutive_failures integer NOT NULL DEFAULT 1
+    CHECK (consecutive_failures > 0),
+  last_failure_at timestamptz NOT NULL,
+  retry_after timestamptz NOT NULL,
+  last_job_id uuid NOT NULL,
+  last_error_message text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (symbol, data_type),
+  CHECK (symbol = upper(btrim(symbol)) AND symbol <> ''),
+  CHECK (retry_after > last_failure_at)
+);
+
+COMMENT ON TABLE public.refresh_failure_cooldowns_v2 IS
+  'Terminal refresh failures that temporarily suppress scheduled requeueing. This table is not successful freshness; demand-driven work may bypass it and successful completion clears it.';
+
+COMMENT ON COLUMN public.refresh_failure_cooldowns_v2.retry_after IS
+  'Earliest time another scheduled priority refresh may be queued. Demand-driven priorities are not blocked.';
+
+CREATE INDEX refresh_failure_cooldowns_v2_retry_after_idx
+  ON public.refresh_failure_cooldowns_v2(retry_after);
+
+ALTER TABLE public.refresh_failure_cooldowns_v2 ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.refresh_failure_cooldowns_v2
+FROM PUBLIC, anon, authenticated;
+
+GRANT SELECT ON TABLE public.refresh_failure_cooldowns_v2 TO service_role;
+
+CREATE OR REPLACE FUNCTION public.refresh_failure_retry_interval_v2(
+  p_error_message text,
+  p_consecutive_failures integer
+)
+RETURNS interval
+LANGUAGE sql
+IMMUTABLE
+SET search_path = ''
+AS $$
+  SELECT CASE
+    WHEN p_error_message ILIKE '%stale%'
+         AND p_error_message ILIKE '%timestamp%'
+      THEN interval '24 hours'
+    ELSE pg_catalog.make_interval(
+      hours => LEAST(
+        24,
+        pg_catalog.power(
+          2,
+          LEAST(GREATEST(p_consecutive_failures, 1) - 1, 5)
+        )::integer
+      )
+    )
+  END;
+$$;
+
+ALTER FUNCTION public.refresh_failure_retry_interval_v2(text, integer)
+OWNER TO postgres;
+
+REVOKE ALL
+ON FUNCTION public.refresh_failure_retry_interval_v2(text, integer)
+FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.is_refresh_failure_cooldown_active_v2(
+  p_symbol text,
+  p_data_type text
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.refresh_failure_cooldowns_v2 AS cooldown
+    WHERE cooldown.symbol = pg_catalog.upper(pg_catalog.btrim(p_symbol))
+      AND cooldown.data_type = p_data_type
+      AND cooldown.retry_after > pg_catalog.now()
+  );
+$$;
+
+ALTER FUNCTION public.is_refresh_failure_cooldown_active_v2(text, text)
+OWNER TO postgres;
+
+REVOKE ALL
+ON FUNCTION public.is_refresh_failure_cooldown_active_v2(text, text)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE
+ON FUNCTION public.is_refresh_failure_cooldown_active_v2(text, text)
+TO service_role;
+
+-- Backfill only recent scheduled terminal failures. This protects the current
+-- rollout anomalies on first resume without reviving years of queue history.
+WITH latest_success AS (
+  SELECT
+    pg_catalog.upper(pg_catalog.btrim(queue.symbol)) AS symbol,
+    queue.data_type,
+    max(queue.processed_at) AS last_success_at
+  FROM public.api_call_queue_v2 AS queue
+  WHERE queue.status = 'completed'
+  GROUP BY
+    pg_catalog.upper(pg_catalog.btrim(queue.symbol)),
+    queue.data_type
+),
+grouped AS (
+  SELECT
+    pg_catalog.upper(pg_catalog.btrim(queue.symbol)) AS symbol,
+    queue.data_type,
+    count(*)::integer AS consecutive_failures,
+    max(queue.processed_at) AS last_failure_at,
+    (array_agg(
+      queue.id
+      ORDER BY queue.processed_at DESC, queue.created_at DESC
+    ))[1] AS last_job_id,
+    (array_agg(
+      queue.error_message
+      ORDER BY queue.processed_at DESC, queue.created_at DESC
+    ))[1] AS last_error_message
+  FROM public.api_call_queue_v2 AS queue
+  JOIN public.data_type_registry_v2 AS registry
+    ON registry.data_type = queue.data_type
+  LEFT JOIN latest_success
+    ON latest_success.symbol =
+      pg_catalog.upper(pg_catalog.btrim(queue.symbol))
+    AND latest_success.data_type = queue.data_type
+  WHERE queue.status = 'failed'
+    AND queue.priority < 0
+    AND queue.processed_at >= now() - interval '7 days'
+    AND queue.processed_at > COALESCE(
+      latest_success.last_success_at,
+      '-infinity'::timestamptz
+    )
+    AND pg_catalog.btrim(queue.symbol) <> ''
+    AND queue.error_message IS NOT NULL
+  GROUP BY
+    pg_catalog.upper(pg_catalog.btrim(queue.symbol)),
+    queue.data_type
+),
+eligible AS (
+  SELECT
+    grouped.*,
+    grouped.last_failure_at
+      + public.refresh_failure_retry_interval_v2(
+          grouped.last_error_message,
+          grouped.consecutive_failures
+        ) AS retry_after
+  FROM grouped
+)
+INSERT INTO public.refresh_failure_cooldowns_v2 (
+  symbol,
+  data_type,
+  consecutive_failures,
+  last_failure_at,
+  retry_after,
+  last_job_id,
+  last_error_message,
+  created_at,
+  updated_at
+)
+SELECT
+  eligible.symbol,
+  eligible.data_type,
+  eligible.consecutive_failures,
+  eligible.last_failure_at,
+  eligible.retry_after,
+  eligible.last_job_id,
+  eligible.last_error_message,
+  now(),
+  now()
+FROM eligible
+WHERE eligible.retry_after > now()
+ON CONFLICT (symbol, data_type) DO NOTHING;
+
+-- Status changes move queue rows between partitions as DELETE + INSERT. An
+-- AFTER INSERT trigger on the partitioned parent therefore observes terminal
+-- failures and successful completions without duplicating queue RPC logic.
+CREATE OR REPLACE FUNCTION public.maintain_refresh_failure_cooldown_v2()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_now timestamptz := pg_catalog.clock_timestamp();
+BEGIN
+  BEGIN
+    IF NEW.status = 'failed'
+       AND NEW.error_message IS NOT NULL
+       AND pg_catalog.btrim(NEW.error_message) <> ''
+    THEN
+      INSERT INTO public.refresh_failure_cooldowns_v2 AS cooldown (
+        symbol,
+        data_type,
+        consecutive_failures,
+        last_failure_at,
+        retry_after,
+        last_job_id,
+        last_error_message,
+        updated_at
+      )
+      VALUES (
+        pg_catalog.upper(pg_catalog.btrim(NEW.symbol)),
+        NEW.data_type,
+        1,
+        v_now,
+        v_now + public.refresh_failure_retry_interval_v2(
+          NEW.error_message,
+          1
+        ),
+        NEW.id,
+        NEW.error_message,
+        v_now
+      )
+      ON CONFLICT (symbol, data_type) DO UPDATE
+      SET
+        consecutive_failures = cooldown.consecutive_failures + 1,
+        last_failure_at = v_now,
+        retry_after = v_now + public.refresh_failure_retry_interval_v2(
+          NEW.error_message,
+          cooldown.consecutive_failures + 1
+        ),
+        last_job_id = NEW.id,
+        last_error_message = NEW.error_message,
+        updated_at = v_now;
+    ELSIF NEW.status = 'completed' THEN
+      DELETE FROM public.refresh_failure_cooldowns_v2 AS cooldown
+      WHERE cooldown.symbol =
+        pg_catalog.upper(pg_catalog.btrim(NEW.symbol))
+        AND cooldown.data_type = NEW.data_type;
+    END IF;
+  EXCEPTION
+    WHEN OTHERS THEN
+      -- Cooldown bookkeeping must never prevent a queue state transition.
+      RAISE WARNING
+        'Unable to maintain refresh failure cooldown for %/%: %',
+        NEW.symbol,
+        NEW.data_type,
+        SQLERRM;
+  END;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.maintain_refresh_failure_cooldown_v2()
+OWNER TO postgres;
+
+REVOKE ALL
+ON FUNCTION public.maintain_refresh_failure_cooldown_v2()
+FROM PUBLIC, anon, authenticated, service_role;
+
+DROP TRIGGER IF EXISTS maintain_refresh_failure_cooldown_v2
+ON public.api_call_queue_v2;
+
+CREATE TRIGGER maintain_refresh_failure_cooldown_v2
+AFTER INSERT ON public.api_call_queue_v2
+FOR EACH ROW
+EXECUTE FUNCTION public.maintain_refresh_failure_cooldown_v2();
+
+COMMENT ON FUNCTION public.maintain_refresh_failure_cooldown_v2() IS
+  'Tracks terminal failures separately from successful freshness and clears the failure state after any successful completion. Bookkeeping errors are warnings and never block queue transitions.';
+
+-- Scheduled priority is negative. Demand-driven work remains able to bypass
+-- cooldown, and its success will clear the failure state.
+CREATE OR REPLACE FUNCTION public.queue_refresh_if_not_exists_v2(
+  p_symbol text,
+  p_data_type text,
+  p_priority integer,
+  p_estimated_size_bytes bigint DEFAULT 0
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SET search_path = public, extensions
+AS $$
+DECLARE
+  job_id uuid;
+  existing_job_id uuid;
+  final_priority integer;
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(p_symbol || chr(31) || p_data_type, 0)
+  );
+
+  IF p_data_type = 'financial-statements'
+     AND p_priority >= 0
+     AND p_priority < 1000
+  THEN
+    final_priority := 500;
+  ELSE
+    final_priority := p_priority;
+  END IF;
+
+  IF final_priority < 0
+     AND public.is_refresh_failure_cooldown_active_v2(
+       p_symbol,
+       p_data_type
+     )
+  THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT queue.id
+  INTO existing_job_id
+  FROM public.api_call_queue_v2 AS queue
+  WHERE queue.symbol = p_symbol
+    AND queue.data_type = p_data_type
+    AND queue.status IN ('pending', 'processing')
+  ORDER BY queue.created_at
+  LIMIT 1;
+
+  IF existing_job_id IS NOT NULL THEN
+    UPDATE public.api_call_queue_v2 AS queue
+    SET priority = GREATEST(queue.priority, final_priority)
+    WHERE queue.id = existing_job_id
+      AND queue.status IN ('pending', 'processing');
+    job_id := existing_job_id;
+  ELSE
+    INSERT INTO public.api_call_queue_v2 (
+      symbol,
+      data_type,
+      status,
+      priority,
+      estimated_data_size_bytes
+    )
+    VALUES (
+      p_symbol,
+      p_data_type,
+      'pending',
+      final_priority,
+      p_estimated_size_bytes
+    )
+    RETURNING api_call_queue_v2.id INTO job_id;
+  END IF;
+
+  RETURN job_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.queue_refresh_if_not_exists_v2(
+  text, text, integer, bigint
+) IS
+  'Idempotently queues refresh work under a symbol/type lock. Negative scheduled priority respects terminal-failure cooldown; demand priorities bypass cooldown and can recover it.';

--- a/tests/contracts/run_all_contracts.sql
+++ b/tests/contracts/run_all_contracts.sql
@@ -85,4 +85,8 @@ END $$;
 \i test_contract_21_financial_source_regression.sql
 
 \echo ''
+\echo 'Running Contract #22: Cross-cycle refresh failure cooldown...'
+\i test_contract_22_refresh_failure_cooldown.sql
+
+\echo ''
 \echo '✅ All contract tests completed!'

--- a/tests/contracts/test_contract_22_refresh_failure_cooldown.sql
+++ b/tests/contracts/test_contract_22_refresh_failure_cooldown.sql
@@ -1,0 +1,393 @@
+-- Contract #22: Cross-cycle Refresh Failure Cooldown
+-- Terminal failures must not be recreated on every scheduled sweep. Cooldown
+-- never counts as successful freshness, demand work may bypass it, and a
+-- subsequent success clears it.
+
+BEGIN;
+SELECT plan(19);
+
+SELECT has_table(
+  'public',
+  'refresh_failure_cooldowns_v2',
+  'Contract #22: terminal failure cooldown state exists'
+);
+
+SELECT ok(
+  (
+    SELECT table_name.relrowsecurity
+    FROM pg_class AS table_name
+    JOIN pg_namespace AS namespace
+      ON namespace.oid = table_name.relnamespace
+    WHERE namespace.nspname = 'public'
+      AND table_name.relname = 'refresh_failure_cooldowns_v2'
+  ),
+  'Contract #22: cooldown state has RLS enabled'
+);
+
+SELECT ok(
+  has_table_privilege(
+    'service_role',
+    'public.refresh_failure_cooldowns_v2',
+    'SELECT'
+  )
+  AND NOT has_table_privilege(
+    'anon',
+    'public.refresh_failure_cooldowns_v2',
+    'SELECT'
+  )
+  AND NOT has_table_privilege(
+    'authenticated',
+    'public.refresh_failure_cooldowns_v2',
+    'SELECT'
+  ),
+  'Contract #22: cooldown diagnostics are operations-only'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc AS procedure
+    JOIN pg_namespace AS namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname = 'public'
+      AND procedure.proname = 'is_refresh_failure_cooldown_active_v2'
+      AND procedure.prosecdef
+  ),
+  'Contract #22: cooldown check is SECURITY DEFINER'
+);
+
+SELECT trigger_is(
+  'public',
+  'api_call_queue_v2',
+  'maintain_refresh_failure_cooldown_v2',
+  'public',
+  'maintain_refresh_failure_cooldown_v2',
+  'Contract #22: queue outcomes maintain cooldown through one trigger'
+);
+
+SELECT is(
+  public.refresh_failure_retry_interval_v2(
+    'Profile validation failed',
+    1
+  ),
+  interval '1 hour',
+  'Contract #22: first generic terminal failure waits one hour'
+);
+
+SELECT is(
+  public.refresh_failure_retry_interval_v2(
+    'Profile validation failed',
+    6
+  ),
+  interval '24 hours',
+  'Contract #22: generic exponential cooldown caps at 24 hours'
+);
+
+SELECT is(
+  public.refresh_failure_retry_interval_v2(
+    'Stale source timestamp: provider returned older data',
+    1
+  ),
+  interval '24 hours',
+  'Contract #22: deterministic timestamp regression waits 24 hours immediately'
+);
+
+DELETE FROM public.api_call_queue_v2
+WHERE symbol IN (
+  'COOLDOWN_TEST',
+  'COOLDOWN_STALE',
+  'COOLDOWN_TRANSIENT'
+);
+
+DELETE FROM public.data_fetch_freshness_v2
+WHERE symbol IN ('COOLDOWN_TEST', 'COOLDOWN_STALE');
+
+DELETE FROM public.refresh_failure_cooldowns_v2
+WHERE symbol IN (
+  'COOLDOWN_TEST',
+  'COOLDOWN_STALE',
+  'COOLDOWN_TRANSIENT'
+);
+
+INSERT INTO public.api_call_queue_v2 (
+  symbol,
+  data_type,
+  status,
+  priority,
+  retry_count,
+  max_retries,
+  estimated_data_size_bytes,
+  processed_at
+)
+VALUES (
+  'COOLDOWN_TRANSIENT',
+  'profile',
+  'processing',
+  -1,
+  0,
+  3,
+  50000,
+  now()
+);
+
+SELECT public.fail_queue_job_v2(
+  (
+    SELECT id
+    FROM public.api_call_queue_v2
+    WHERE symbol = 'COOLDOWN_TRANSIENT'
+      AND data_type = 'profile'
+      AND status = 'processing'
+    ORDER BY created_at DESC
+    LIMIT 1
+  ),
+  'Temporary provider failure',
+  1000
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM public.api_call_queue_v2
+    WHERE symbol = 'COOLDOWN_TRANSIENT'
+      AND data_type = 'profile'
+      AND status = 'pending'
+      AND retry_count = 1
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.refresh_failure_cooldowns_v2
+    WHERE symbol = 'COOLDOWN_TRANSIENT'
+      AND data_type = 'profile'
+  ),
+  'Contract #22: in-cycle retry does not create cross-cycle cooldown'
+);
+
+SELECT public.record_data_fetch_freshness_v2(
+  'COOLDOWN_TEST',
+  'profile',
+  true,
+  100
+);
+
+CREATE TEMP TABLE cooldown_freshness_fixture AS
+SELECT last_success_at
+FROM public.data_fetch_freshness_v2
+WHERE symbol = 'COOLDOWN_TEST'
+  AND data_type = 'profile';
+
+INSERT INTO public.api_call_queue_v2 (
+  symbol,
+  data_type,
+  status,
+  priority,
+  retry_count,
+  max_retries,
+  estimated_data_size_bytes,
+  processed_at
+)
+VALUES (
+  'COOLDOWN_TEST',
+  'profile',
+  'processing',
+  -1,
+  3,
+  3,
+  50000,
+  now()
+);
+
+SELECT lives_ok(
+  $$
+    SELECT public.fail_queue_job_v2(
+      (
+        SELECT id
+        FROM public.api_call_queue_v2
+        WHERE symbol = 'COOLDOWN_TEST'
+          AND data_type = 'profile'
+          AND status = 'processing'
+        ORDER BY created_at DESC
+        LIMIT 1
+      ),
+      'Profile validation failed',
+      1000
+    )
+  $$,
+  'Contract #22: terminal generic failure records queue and cooldown state'
+);
+
+SELECT is(
+  (
+    SELECT consecutive_failures = 1 AND retry_after > now()
+    FROM public.refresh_failure_cooldowns_v2
+    WHERE symbol = 'COOLDOWN_TEST'
+      AND data_type = 'profile'
+  ),
+  true,
+  'Contract #22: first terminal failure activates one cooldown record'
+);
+
+INSERT INTO public.api_call_queue_v2 (
+  symbol,
+  data_type,
+  status,
+  priority,
+  retry_count,
+  max_retries,
+  estimated_data_size_bytes,
+  processed_at,
+  error_message
+)
+VALUES (
+  'COOLDOWN_TEST',
+  'profile',
+  'failed',
+  -1,
+  3,
+  3,
+  50000,
+  now(),
+  'Profile validation failed again'
+);
+
+SELECT ok(
+  (
+    SELECT consecutive_failures = 2
+      AND retry_after >= last_failure_at + interval '1 hour 59 minutes'
+    FROM public.refresh_failure_cooldowns_v2
+    WHERE symbol = 'COOLDOWN_TEST'
+      AND data_type = 'profile'
+  ),
+  'Contract #22: repeated terminal failure advances exponential cooldown'
+);
+
+SELECT is(
+  (
+    SELECT freshness.last_success_at
+    FROM public.data_fetch_freshness_v2 AS freshness
+    WHERE freshness.symbol = 'COOLDOWN_TEST'
+      AND freshness.data_type = 'profile'
+  ),
+  (
+    SELECT fixture.last_success_at
+    FROM cooldown_freshness_fixture AS fixture
+  ),
+  'Contract #22: failure does not advance successful freshness'
+);
+
+SELECT is(
+  public.queue_refresh_if_not_exists_v2(
+    'COOLDOWN_TEST',
+    'profile',
+    -1,
+    50000
+  ),
+  NULL::uuid,
+  'Contract #22: active cooldown suppresses scheduled requeue'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.api_call_queue_v2
+    WHERE symbol = 'COOLDOWN_TEST'
+      AND data_type = 'profile'
+      AND status IN ('pending', 'processing')
+  ),
+  0,
+  'Contract #22: suppressed scheduled work creates no active job'
+);
+
+SELECT isnt(
+  public.queue_refresh_if_not_exists_v2(
+    'COOLDOWN_TEST',
+    'profile',
+    10,
+    50000
+  ),
+  NULL::uuid,
+  'Contract #22: demand-driven work bypasses cooldown'
+);
+
+UPDATE public.api_call_queue_v2
+SET
+  status = 'processing',
+  processed_at = now()
+WHERE symbol = 'COOLDOWN_TEST'
+  AND data_type = 'profile'
+  AND status = 'pending';
+
+SELECT lives_ok(
+  $$
+    SELECT public.complete_queue_job_v2(
+      (
+        SELECT id
+        FROM public.api_call_queue_v2
+        WHERE symbol = 'COOLDOWN_TEST'
+          AND data_type = 'profile'
+          AND status = 'processing'
+        ORDER BY created_at DESC
+        LIMIT 1
+      ),
+      50000,
+      1
+    )
+  $$,
+  'Contract #22: a successful bypass job completes normally'
+);
+
+SELECT is(
+  public.is_refresh_failure_cooldown_active_v2(
+    'COOLDOWN_TEST',
+    'profile'
+  ),
+  false,
+  'Contract #22: successful completion clears prior cooldown'
+);
+
+INSERT INTO public.api_call_queue_v2 (
+  symbol,
+  data_type,
+  status,
+  priority,
+  retry_count,
+  max_retries,
+  estimated_data_size_bytes,
+  processed_at
+)
+VALUES (
+  'COOLDOWN_STALE',
+  'financial-statements',
+  'processing',
+  -1,
+  0,
+  3,
+  600000,
+  now()
+);
+
+SELECT public.fail_queue_job_v2(
+  (
+    SELECT id
+    FROM public.api_call_queue_v2
+    WHERE symbol = 'COOLDOWN_STALE'
+      AND data_type = 'financial-statements'
+      AND status = 'processing'
+    ORDER BY created_at DESC
+    LIMIT 1
+  ),
+  'Stale source timestamp: provider returned older data',
+  600000
+);
+
+SELECT ok(
+  (
+    SELECT retry_after >= last_failure_at + interval '23 hours 59 minutes'
+    FROM public.refresh_failure_cooldowns_v2
+    WHERE symbol = 'COOLDOWN_STALE'
+      AND data_type = 'financial-statements'
+  ),
+  'Contract #22: source regression receives the deterministic 24-hour cooldown'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Prevents failed symbols from being recreated every sweep, preserves true freshness semantics, allows demand refreshes, and clears cooldown after success.