### PR TITLE
Restore persistent data quality validators

### DIFF
--- a/scripts/security/verify-data-quality-issues.sql
+++ b/scripts/security/verify-data-quality-issues.sql
@@ -1,0 +1,130 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $$
+DECLARE
+    v_detected_at TIMESTAMPTZ;
+    v_occurrence_count INTEGER;
+    v_status TEXT;
+    v_resolved_at TIMESTAMPTZ;
+BEGIN
+    PERFORM public.sync_data_quality_issues(
+        'QA-TEST',
+        'fmp',
+        'quote',
+        '[{
+          "check_code": "market_cap_reconciliation",
+          "field_name": "marketCap",
+          "severity": "warning",
+          "message": "Initial test finding",
+          "evidence": {"relativeDifference": 0.10},
+          "source_reference": "price-times-shares"
+        }]'::JSONB
+    );
+
+    SELECT detected_at, occurrence_count, status
+    INTO v_detected_at, v_occurrence_count, v_status
+    FROM public.data_quality_issues
+    WHERE symbol = 'QA-TEST'
+      AND check_code = 'market_cap_reconciliation';
+
+    IF v_occurrence_count <> 1 OR v_status <> 'open' THEN
+        RAISE EXCEPTION 'Initial finding was not opened correctly';
+    END IF;
+
+    PERFORM public.sync_data_quality_issues(
+        'QA-TEST',
+        'fmp',
+        'quote',
+        '[{
+          "check_code": "market_cap_reconciliation",
+          "field_name": "marketCap",
+          "severity": "critical",
+          "message": "Repeated test finding",
+          "evidence": {"relativeDifference": 0.30},
+          "source_reference": "price-times-shares"
+        }]'::JSONB
+    );
+
+    SELECT occurrence_count, status
+    INTO v_occurrence_count, v_status
+    FROM public.data_quality_issues
+    WHERE symbol = 'QA-TEST'
+      AND check_code = 'market_cap_reconciliation';
+
+    IF v_occurrence_count <> 2 OR v_status <> 'open' THEN
+        RAISE EXCEPTION 'Repeated finding was not reinforced correctly';
+    END IF;
+
+    IF (
+        SELECT detected_at
+        FROM public.data_quality_issues
+        WHERE symbol = 'QA-TEST'
+          AND check_code = 'market_cap_reconciliation'
+    ) <> v_detected_at THEN
+        RAISE EXCEPTION 'Original detection timestamp was not preserved';
+    END IF;
+
+    PERFORM public.sync_data_quality_issues(
+        'QA-TEST',
+        'fmp',
+        'quote',
+        '[]'::JSONB
+    );
+
+    SELECT status, resolved_at
+    INTO v_status, v_resolved_at
+    FROM public.data_quality_issues
+    WHERE symbol = 'QA-TEST'
+      AND check_code = 'market_cap_reconciliation';
+
+    IF v_status <> 'resolved' OR v_resolved_at IS NULL THEN
+        RAISE EXCEPTION 'Absent finding was not resolved correctly';
+    END IF;
+
+    PERFORM public.sync_data_quality_issues(
+        'QA-TEST',
+        'fmp',
+        'quote',
+        '[{
+          "check_code": "market_cap_reconciliation",
+          "field_name": "marketCap",
+          "severity": "warning",
+          "message": "Recurring test finding",
+          "evidence": {"relativeDifference": 0.11},
+          "source_reference": "price-times-shares"
+        }]'::JSONB
+    );
+
+    SELECT occurrence_count, status, resolved_at
+    INTO v_occurrence_count, v_status, v_resolved_at
+    FROM public.data_quality_issues
+    WHERE symbol = 'QA-TEST'
+      AND check_code = 'market_cap_reconciliation';
+
+    IF v_occurrence_count <> 3 OR v_status <> 'open' OR v_resolved_at IS NOT NULL THEN
+        RAISE EXCEPTION 'Recurring finding was not reopened correctly';
+    END IF;
+
+    IF has_function_privilege(
+        'anon',
+        'public.sync_data_quality_issues(text,text,text,jsonb)',
+        'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION 'anon must not execute sync_data_quality_issues';
+    END IF;
+
+    IF NOT has_table_privilege('anon', 'public.data_quality_issues', 'SELECT') THEN
+        RAISE EXCEPTION 'anon should be able to read data-quality findings';
+    END IF;
+
+    IF has_table_privilege('anon', 'public.data_quality_issues', 'INSERT') THEN
+        RAISE EXCEPTION 'anon must not insert data-quality findings';
+    END IF;
+END;
+$$;
+
+ROLLBACK;
+
+SELECT 'data-quality issue verification passed' AS result;

--- a/src/lib/__tests__/data-quality-validation.test.ts
+++ b/src/lib/__tests__/data-quality-validation.test.ts
@@ -1,0 +1,117 @@
+import {
+  validateBalanceSheetReconciliation,
+  validateMarketCapReconciliation,
+  validateReportingPeriodIntegrity,
+} from "../../../supabase/functions/_shared/data-quality-validation";
+
+describe("provider data-quality validators", () => {
+  describe("balance-sheet reconciliation", () => {
+    it("returns no finding when assets reconcile", () => {
+      const findings = validateBalanceSheetReconciliation({
+        date: "2025-12-31",
+        period: "FY",
+        balance_sheet_payload: {
+          totalAssets: 1_000,
+          totalLiabilities: 600,
+          totalEquity: 400,
+        },
+      });
+
+      expect(findings).toEqual([]);
+    });
+
+    it("raises a critical finding for a material accounting-equation mismatch", () => {
+      const findings = validateBalanceSheetReconciliation({
+        date: "2025-12-31",
+        period: "FY",
+        balance_sheet_payload: {
+          totalAssets: 1_000,
+          totalLiabilities: 500,
+          totalEquity: 300,
+        },
+      });
+
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        checkCode: "balance_sheet_reconciliation",
+        severity: "critical",
+        sourceDate: "2025-12-31",
+      });
+    });
+
+    it("records an informational finding when the check cannot run", () => {
+      const findings = validateBalanceSheetReconciliation({
+        date: "2025-12-31",
+        period: "FY",
+        balance_sheet_payload: { totalAssets: 1_000 },
+      });
+
+      expect(findings[0]).toMatchObject({
+        severity: "info",
+        sourceReference: "missing-inputs",
+      });
+    });
+  });
+
+  describe("market-cap reconciliation", () => {
+    it("returns no finding within the tolerance", () => {
+      expect(validateMarketCapReconciliation({
+        price: 10,
+        sharesOutstanding: 100,
+        marketCap: 1_030,
+      })).toEqual([]);
+    });
+
+    it("raises a critical finding for a material mismatch", () => {
+      const findings = validateMarketCapReconciliation({
+        price: 10,
+        sharesOutstanding: 100,
+        marketCap: 1_500,
+      });
+
+      expect(findings[0]).toMatchObject({
+        checkCode: "market_cap_reconciliation",
+        severity: "critical",
+      });
+    });
+  });
+
+  describe("reporting-period integrity", () => {
+    const now = new Date("2026-07-27T12:00:00.000Z");
+
+    it("detects future periods and filings before the period end", () => {
+      const findings = validateReportingPeriodIntegrity(
+        [{
+          date: "2026-12-31",
+          period: "FY",
+          fiscal_year: "2026",
+          filing_date: "2026-01-15",
+          accepted_date: "2026-01-15T12:00:00.000Z",
+        }],
+        now,
+      );
+
+      expect(findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({ sourceReference: "future-period" }),
+        expect.objectContaining({ sourceReference: "filing-before-period" }),
+      ]));
+    });
+
+    it("detects multiple dates mapped to one fiscal period", () => {
+      const findings = validateReportingPeriodIntegrity(
+        [
+          { date: "2025-12-30", period: "FY", fiscal_year: "2025" },
+          { date: "2025-12-31", period: "FY", fiscal_year: "2025" },
+        ],
+        now,
+      );
+
+      expect(findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          severity: "warning",
+          sourceReference: "duplicate-2025:FY",
+        }),
+      ]));
+    });
+  });
+});

--- a/supabase/functions/__tests__/data-quality-wiring.test.ts
+++ b/supabase/functions/__tests__/data-quality-wiring.test.ts
@@ -1,0 +1,219 @@
+import {
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { QueueJob } from "../lib/types.ts";
+
+Deno.env.set("FMP_API_KEY", "data-quality-wiring-test-key");
+
+const { fetchFinancialStatementsLogic } = await import(
+  "../lib/fetch-fmp-financial-statements.ts?data-quality-wiring-test"
+);
+const { fetchQuoteLogic } = await import(
+  "../lib/fetch-fmp-quote.ts?data-quality-wiring-test"
+);
+
+interface RpcCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+function queueJob(dataType: string): QueueJob {
+  return {
+    id: `job-${dataType}`,
+    symbol: "TEST",
+    data_type: dataType,
+    status: "processing",
+    priority: -1,
+    retry_count: 0,
+    max_retries: 3,
+    created_at: "2026-08-01T00:00:00Z",
+    estimated_data_size_bytes: 1,
+    job_metadata: {},
+  };
+}
+
+Deno.test(
+  "financial statement queue handler synchronizes deterministic findings",
+  async () => {
+    const originalFetch = globalThis.fetch;
+    const rpcCalls: RpcCall[] = [];
+    const baseStatement = {
+      date: "2025-12-31",
+      symbol: "TEST",
+      reportedCurrency: "USD",
+      cik: "0000000001",
+      filingDate: "2026-02-01",
+      acceptedDate: "2026-02-01T12:00:00Z",
+      fiscalYear: "2025",
+      period: "FY",
+    };
+    const responses = [
+      { ...baseStatement, revenue: 1_000 },
+      {
+        ...baseStatement,
+        totalAssets: 1_000,
+        totalLiabilities: 600,
+        totalEquity: 400,
+      },
+      { ...baseStatement, operatingCashFlow: 100 },
+    ];
+
+    try {
+      globalThis.fetch = () => {
+        const payload = responses.shift();
+        if (!payload) throw new Error("Unexpected fourth FMP request");
+        return Promise.resolve(
+          new Response(JSON.stringify([payload]), {
+            status: 200,
+            headers: { "Content-Length": "100" },
+          }),
+        );
+      };
+
+      const supabase = {
+        rpc: (name: string, args: Record<string, unknown>) => {
+          rpcCalls.push({ name, args });
+          return Promise.resolve({ error: null });
+        },
+        from: (table: string) => {
+          if (table === "data_type_registry_v2") {
+            const chain = {
+              select: () => chain,
+              eq: () => chain,
+              single: () =>
+                Promise.resolve({
+                  data: { source_timestamp_column: "accepted_date" },
+                  error: null,
+                }),
+            };
+            return chain;
+          }
+
+          if (table === "financial_statements") {
+            const chain = {
+              select: () => chain,
+              eq: () => chain,
+              not: () => chain,
+              order: () => chain,
+              limit: () => chain,
+              maybeSingle: () => Promise.resolve({ data: null, error: null }),
+              upsert: () => Promise.resolve({ error: null }),
+            };
+            return chain;
+          }
+
+          throw new Error(`Unexpected table access: ${table}`);
+        },
+      } as unknown as SupabaseClient;
+
+      const result = await fetchFinancialStatementsLogic(
+        queueJob("financial-statements"),
+        supabase,
+      );
+
+      assertEquals(result.success, true);
+      assertEquals(result.dataSizeBytes, 300);
+      assertEquals(responses, []);
+      assertEquals(
+        rpcCalls.map((call) => call.name),
+        [
+          "sync_data_quality_issues",
+          "record_data_fetch_freshness_v2",
+          "resolve_data_quality_issue_v2",
+        ],
+      );
+      assertEquals(rpcCalls[0].args, {
+        p_symbol: "TEST",
+        p_provider: "fmp",
+        p_endpoint: "financial-statements",
+        p_findings: [],
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);
+
+Deno.test(
+  "quote queue handler persists market-cap reconciliation findings",
+  async () => {
+    const originalFetch = globalThis.fetch;
+    const rpcCalls: RpcCall[] = [];
+
+    try {
+      globalThis.fetch = () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify([{
+              symbol: "TEST",
+              price: 10,
+              timestamp: 1_700_000_000,
+              marketCap: 1_500,
+              sharesOutstanding: 100,
+            }]),
+            {
+              status: 200,
+              headers: { "Content-Length": "200" },
+            },
+          ),
+        );
+
+      const supabase = {
+        rpc: (name: string, args: Record<string, unknown>) => {
+          rpcCalls.push({ name, args });
+          return Promise.resolve({ error: null });
+        },
+        from: (table: string) => {
+          if (table === "data_type_registry_v2") {
+            const chain = {
+              select: () => chain,
+              eq: () => chain,
+              single: () =>
+                Promise.resolve({
+                  data: { source_timestamp_column: "api_timestamp" },
+                  error: null,
+                }),
+            };
+            return chain;
+          }
+
+          if (table === "live_quote_indicators") {
+            const chain = {
+              select: () => chain,
+              eq: () => chain,
+              single: () =>
+                Promise.resolve({
+                  data: null,
+                  error: { code: "PGRST116" },
+                }),
+              upsert: () => Promise.resolve({ error: null }),
+            };
+            return chain;
+          }
+
+          throw new Error(`Unexpected table access: ${table}`);
+        },
+      } as unknown as SupabaseClient;
+
+      const result = await fetchQuoteLogic(queueJob("quote"), supabase);
+
+      assertEquals(result.success, true);
+      assertEquals(result.dataSizeBytes, 200);
+      assertEquals(rpcCalls.map((call) => call.name), [
+        "sync_data_quality_issues",
+      ]);
+
+      const findings = rpcCalls[0].args.p_findings as Array<
+        Record<string, unknown>
+      >;
+      assertEquals(findings.length, 1);
+      assertEquals(findings[0].check_code, "market_cap_reconciliation");
+      assertEquals(findings[0].severity, "critical");
+      assertExists(findings[0].evidence);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);

--- a/supabase/functions/_shared/data-quality-persistence.ts
+++ b/supabase/functions/_shared/data-quality-persistence.ts
@@ -1,0 +1,41 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { DataQualityFinding } from "./data-quality-validation.ts";
+
+interface DataQualityScope {
+  symbol: string;
+  provider: string;
+  endpoint: string;
+}
+
+export async function syncDataQualityFindings(
+  supabase: SupabaseClient,
+  scope: DataQualityScope,
+  findings: DataQualityFinding[],
+): Promise<boolean> {
+  const serializedFindings = findings.map((finding) => ({
+    check_code: finding.checkCode,
+    field_name: finding.fieldName ?? null,
+    severity: finding.severity,
+    message: finding.message,
+    evidence: finding.evidence,
+    source_date: finding.sourceDate ?? null,
+    source_period: finding.sourcePeriod ?? null,
+    source_reference: finding.sourceReference ?? null,
+  }));
+
+  const { error } = await supabase.rpc("sync_data_quality_issues", {
+    p_symbol: scope.symbol,
+    p_provider: scope.provider,
+    p_endpoint: scope.endpoint,
+    p_findings: serializedFindings,
+  });
+
+  if (error) {
+    console.error(
+      `[data-quality] Failed to persist findings for ${scope.symbol}/${scope.endpoint}: ${error.message}`,
+    );
+    return false;
+  }
+
+  return true;
+}

--- a/supabase/functions/_shared/data-quality-validation.ts
+++ b/supabase/functions/_shared/data-quality-validation.ts
@@ -1,0 +1,372 @@
+export type DataQualitySeverity = "info" | "warning" | "critical";
+
+export interface DataQualityFinding {
+  checkCode: string;
+  fieldName?: string;
+  severity: DataQualitySeverity;
+  message: string;
+  evidence: Record<string, unknown>;
+  sourceDate?: string;
+  sourcePeriod?: string;
+  sourceReference?: string;
+}
+
+export interface FinancialStatementForValidation {
+  date?: unknown;
+  period?: unknown;
+  fiscal_year?: unknown;
+  filing_date?: unknown;
+  accepted_date?: unknown;
+  balance_sheet_payload?: unknown;
+}
+
+export interface MarketCapForValidation {
+  price?: unknown;
+  marketCap?: unknown;
+  sharesOutstanding?: unknown;
+  timestamp?: unknown;
+}
+
+const BALANCE_WARNING_THRESHOLD = 0.01;
+const BALANCE_CRITICAL_THRESHOLD = 0.05;
+const MARKET_CAP_WARNING_THRESHOLD = 0.05;
+const MARKET_CAP_CRITICAL_THRESHOLD = 0.20;
+const FUTURE_PERIOD_GRACE_DAYS = 7;
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function parseIsoDate(value: unknown): Date | null {
+  if (typeof value !== "string") return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return date.getUTCFullYear() === year &&
+      date.getUTCMonth() === month - 1 &&
+      date.getUTCDate() === day
+    ? date
+    : null;
+}
+
+function parseTimestamp(value: unknown): Date | null {
+  if (typeof value !== "string") return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function validateBalanceSheetReconciliation(
+  statement: FinancialStatementForValidation,
+): DataQualityFinding[] {
+  const sourceDate = stringValue(statement.date);
+  const sourcePeriod = stringValue(statement.period);
+  const payload = statement.balance_sheet_payload &&
+      typeof statement.balance_sheet_payload === "object"
+    ? statement.balance_sheet_payload as Record<string, unknown>
+    : null;
+
+  if (!payload) {
+    return [{
+      checkCode: "balance_sheet_reconciliation",
+      fieldName: "balance_sheet_payload",
+      severity: "info",
+      message:
+        "Balance sheet reconciliation could not be evaluated because the payload is missing.",
+      evidence: { missingFields: ["balance_sheet_payload"] },
+      sourceDate,
+      sourcePeriod,
+      sourceReference: "missing-inputs",
+    }];
+  }
+
+  const totalAssets = finiteNumber(payload.totalAssets);
+  const totalLiabilities = finiteNumber(payload.totalLiabilities);
+  const totalEquity = finiteNumber(payload.totalEquity);
+  const missingFields = [
+    totalAssets === null ? "totalAssets" : null,
+    totalLiabilities === null ? "totalLiabilities" : null,
+    totalEquity === null ? "totalEquity" : null,
+  ].filter((field): field is string => field !== null);
+
+  if (
+    totalAssets === null ||
+    totalLiabilities === null ||
+    totalEquity === null
+  ) {
+    return [{
+      checkCode: "balance_sheet_reconciliation",
+      fieldName: "balance_sheet_payload",
+      severity: "info",
+      message:
+        "Balance sheet reconciliation could not be fully evaluated because required fields are missing.",
+      evidence: { missingFields },
+      sourceDate,
+      sourcePeriod,
+      sourceReference: "missing-inputs",
+    }];
+  }
+
+  if (totalAssets <= 0) {
+    return [{
+      checkCode: "balance_sheet_reconciliation",
+      fieldName: "totalAssets",
+      severity: "critical",
+      message: "Reported total assets are not positive.",
+      evidence: { totalAssets, totalLiabilities, totalEquity },
+      sourceDate,
+      sourcePeriod,
+      sourceReference: "non-positive-assets",
+    }];
+  }
+
+  const liabilitiesAndEquity = totalLiabilities + totalEquity;
+  const absoluteDifference = Math.abs(totalAssets - liabilitiesAndEquity);
+  const relativeDifference = absoluteDifference / Math.abs(totalAssets);
+
+  if (relativeDifference <= BALANCE_WARNING_THRESHOLD) {
+    return [];
+  }
+
+  return [{
+    checkCode: "balance_sheet_reconciliation",
+    fieldName: "totalAssets",
+    severity: relativeDifference > BALANCE_CRITICAL_THRESHOLD
+      ? "critical"
+      : "warning",
+    message:
+      "Total assets do not reconcile with total liabilities plus total equity.",
+    evidence: {
+      totalAssets,
+      totalLiabilities,
+      totalEquity,
+      liabilitiesAndEquity,
+      absoluteDifference,
+      relativeDifference,
+      warningThreshold: BALANCE_WARNING_THRESHOLD,
+    },
+    sourceDate,
+    sourcePeriod,
+    sourceReference: "accounting-equation",
+  }];
+}
+
+export function validateMarketCapReconciliation(
+  quote: MarketCapForValidation,
+): DataQualityFinding[] {
+  const price = finiteNumber(quote.price);
+  const marketCap = finiteNumber(quote.marketCap);
+  const sharesOutstanding = finiteNumber(quote.sharesOutstanding);
+  const missingFields = [
+    price === null ? "price" : null,
+    marketCap === null ? "marketCap" : null,
+    sharesOutstanding === null ? "sharesOutstanding" : null,
+  ].filter((field): field is string => field !== null);
+
+  if (
+    price === null ||
+    marketCap === null ||
+    sharesOutstanding === null
+  ) {
+    return [{
+      checkCode: "market_cap_reconciliation",
+      fieldName: "marketCap",
+      severity: "info",
+      message:
+        "Market-cap reconciliation could not be fully evaluated because required fields are missing.",
+      evidence: { missingFields },
+      sourceReference: "missing-inputs",
+    }];
+  }
+
+  const expectedMarketCap = price * sharesOutstanding;
+  if (
+    price <= 0 || marketCap <= 0 || sharesOutstanding <= 0 ||
+    expectedMarketCap <= 0
+  ) {
+    return [{
+      checkCode: "market_cap_reconciliation",
+      fieldName: "marketCap",
+      severity: "warning",
+      message: "Market-cap reconciliation received a non-positive input.",
+      evidence: { price, marketCap, sharesOutstanding, expectedMarketCap },
+      sourceReference: "non-positive-input",
+    }];
+  }
+
+  const absoluteDifference = Math.abs(marketCap - expectedMarketCap);
+  const relativeDifference = absoluteDifference / expectedMarketCap;
+
+  if (relativeDifference <= MARKET_CAP_WARNING_THRESHOLD) {
+    return [];
+  }
+
+  return [{
+    checkCode: "market_cap_reconciliation",
+    fieldName: "marketCap",
+    severity: relativeDifference > MARKET_CAP_CRITICAL_THRESHOLD
+      ? "critical"
+      : "warning",
+    message:
+      "Reported market cap does not reconcile with price multiplied by shares outstanding.",
+    evidence: {
+      price,
+      marketCap,
+      sharesOutstanding,
+      expectedMarketCap,
+      absoluteDifference,
+      relativeDifference,
+      warningThreshold: MARKET_CAP_WARNING_THRESHOLD,
+    },
+    sourceReference: "price-times-shares",
+  }];
+}
+
+export function validateReportingPeriodIntegrity(
+  statements: FinancialStatementForValidation[],
+  now = new Date(),
+): DataQualityFinding[] {
+  const findings: DataQualityFinding[] = [];
+  const canonicalPeriods = new Map<string, Set<string>>();
+  const futureBoundary = new Date(
+    now.getTime() + FUTURE_PERIOD_GRACE_DAYS * 86_400_000,
+  );
+
+  statements.forEach((statement, index) => {
+    const sourceDate = stringValue(statement.date);
+    const sourcePeriod = stringValue(statement.period);
+    const fiscalYear = stringValue(statement.fiscal_year);
+    const periodDate = parseIsoDate(statement.date);
+
+    if (!sourceDate || !periodDate) {
+      findings.push({
+        checkCode: "reporting_period_integrity",
+        fieldName: "date",
+        severity: "critical",
+        message: "Financial statement has a missing or invalid reporting date.",
+        evidence: { observedDate: statement.date ?? null, rowIndex: index },
+        sourcePeriod,
+        sourceReference: `row-${index}-invalid-date`,
+      });
+      return;
+    }
+
+    if (!sourcePeriod) {
+      findings.push({
+        checkCode: "reporting_period_integrity",
+        fieldName: "period",
+        severity: "critical",
+        message: "Financial statement has a missing reporting period.",
+        evidence: { sourceDate, rowIndex: index },
+        sourceDate,
+        sourceReference: `row-${index}-missing-period`,
+      });
+    }
+
+    if (periodDate > futureBoundary) {
+      findings.push({
+        checkCode: "reporting_period_integrity",
+        fieldName: "date",
+        severity: "critical",
+        message:
+          "Financial statement reporting date is unexpectedly in the future.",
+        evidence: {
+          sourceDate,
+          checkedAt: now.toISOString(),
+          graceDays: FUTURE_PERIOD_GRACE_DAYS,
+        },
+        sourceDate,
+        sourcePeriod,
+        sourceReference: "future-period",
+      });
+    }
+
+    const filingDate = parseIsoDate(statement.filing_date);
+    if (statement.filing_date && !filingDate) {
+      findings.push({
+        checkCode: "reporting_period_integrity",
+        fieldName: "filing_date",
+        severity: "warning",
+        message: "Financial statement has an invalid filing date.",
+        evidence: { filingDate: statement.filing_date },
+        sourceDate,
+        sourcePeriod,
+        sourceReference: "invalid-filing-date",
+      });
+    } else if (filingDate && filingDate < periodDate) {
+      findings.push({
+        checkCode: "reporting_period_integrity",
+        fieldName: "filing_date",
+        severity: "warning",
+        message:
+          "Financial statement filing date precedes its reporting-period end date.",
+        evidence: { sourceDate, filingDate: statement.filing_date },
+        sourceDate,
+        sourcePeriod,
+        sourceReference: "filing-before-period",
+      });
+    }
+
+    const acceptedDate = parseTimestamp(statement.accepted_date);
+    if (statement.accepted_date && !acceptedDate) {
+      findings.push({
+        checkCode: "reporting_period_integrity",
+        fieldName: "accepted_date",
+        severity: "warning",
+        message: "Financial statement has an invalid accepted timestamp.",
+        evidence: { acceptedDate: statement.accepted_date },
+        sourceDate,
+        sourcePeriod,
+        sourceReference: "invalid-accepted-date",
+      });
+    } else if (acceptedDate && filingDate && acceptedDate < filingDate) {
+      findings.push({
+        checkCode: "reporting_period_integrity",
+        fieldName: "accepted_date",
+        severity: "warning",
+        message:
+          "Financial statement acceptance timestamp precedes its filing date.",
+        evidence: {
+          filingDate: statement.filing_date,
+          acceptedDate: statement.accepted_date,
+        },
+        sourceDate,
+        sourcePeriod,
+        sourceReference: "accepted-before-filing",
+      });
+    }
+
+    if (sourcePeriod) {
+      const canonicalKey = `${
+        fiscalYear ?? periodDate.getUTCFullYear()
+      }:${sourcePeriod}`;
+      const dates = canonicalPeriods.get(canonicalKey) ?? new Set<string>();
+      dates.add(sourceDate);
+      canonicalPeriods.set(canonicalKey, dates);
+    }
+  });
+
+  canonicalPeriods.forEach((dates, canonicalPeriod) => {
+    if (dates.size <= 1) return;
+    const observedDates = [...dates].sort();
+    findings.push({
+      checkCode: "reporting_period_integrity",
+      fieldName: "fiscal_year",
+      severity: "warning",
+      message:
+        "Multiple reporting dates map to the same fiscal year and period.",
+      evidence: { canonicalPeriod, observedDates },
+      sourceReference: `duplicate-${canonicalPeriod}`,
+    });
+  });
+
+  return findings;
+}

--- a/supabase/functions/lib/fetch-fmp-financial-statements.ts
+++ b/supabase/functions/lib/fetch-fmp-financial-statements.ts
@@ -13,6 +13,11 @@ import type {
   FmpIncomeStatementEntry,
   FmpStatementEntryBase,
 } from "../fetch-fmp-financial-statements/types.ts";
+import { syncDataQualityFindings } from "../_shared/data-quality-persistence.ts";
+import {
+  validateBalanceSheetReconciliation,
+  validateReportingPeriodIntegrity,
+} from "../_shared/data-quality-validation.ts";
 import {
   recordFinancialSourceRegression,
   resolveFinancialSourceRegression,
@@ -306,6 +311,23 @@ export async function fetchFinancialStatementsLogic(
       if (upsertError) {
         throw new Error(`Database upsert failed: ${upsertError.message}`);
       }
+
+      const dataQualityFindings = [
+        ...statementsForSymbolUpsert.flatMap((statement) =>
+          validateBalanceSheetReconciliation(statement)
+        ),
+        ...validateReportingPeriodIntegrity(statementsForSymbolUpsert),
+      ];
+
+      await syncDataQualityFindings(
+        supabase,
+        {
+          symbol: job.symbol,
+          provider: "fmp",
+          endpoint: "financial-statements",
+        },
+        dataQualityFindings,
+      );
 
       await recordDataFetchFreshness(
         supabase,

--- a/supabase/functions/lib/fetch-fmp-quote.ts
+++ b/supabase/functions/lib/fetch-fmp-quote.ts
@@ -5,6 +5,8 @@
 import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { QueueJob, ProcessJobResult } from './types.ts';
+import { syncDataQualityFindings } from '../_shared/data-quality-persistence.ts';
+import { validateMarketCapReconciliation } from '../_shared/data-quality-validation.ts';
 
 const FMP_API_KEY = Deno.env.get('FMP_API_KEY');
 const FMP_QUOTE_BASE_URL = 'https://financialmodelingprep.com/stable/quote';
@@ -184,6 +186,16 @@ export async function fetchQuoteLogic(
     if (upsertError) {
       throw new Error(`Database upsert failed: ${upsertError.message}`);
     }
+
+    await syncDataQualityFindings(
+      supabase,
+      {
+        symbol: quote.symbol,
+        provider: 'fmp',
+        endpoint: 'quote',
+      },
+      validateMarketCapReconciliation(quote)
+    );
 
     return {
       success: true,


### PR DESCRIPTION
Restores deterministic data-quality validation that was stranded on an unmerged feature branch. Wires balance-sheet and reporting-period checks into financial-statement processing, and market-cap reconciliation into quote processing. Adds queue-level tests and database lifecycle/permission verification while preserving current freshness, quota, source-regression, and cooldown behavior. No migration or FMP calls.