### PR TITLE
Allow EDGAR next-business-day filing dates

### DIFF
--- a/src/lib/__tests__/data-quality-validation.test.ts
+++ b/src/lib/__tests__/data-quality-validation.test.ts
@@ -97,6 +97,40 @@ describe("provider data-quality validators", () => {
       ]));
     });
 
+    it("allows EDGAR acceptance before the next-business-day filing date", () => {
+      const findings = validateReportingPeriodIntegrity([{
+        date: "2024-12-31",
+        period: "FY",
+        fiscal_year: "2024",
+        filing_date: "2025-01-06",
+        accepted_date: "2025-01-03T19:00:00.000Z",
+      }], now);
+
+      expect(findings).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          sourceReference: "accepted-before-filing",
+        }),
+      ]));
+    });
+
+    it("detects acceptance timestamps materially before filing", () => {
+      const findings = validateReportingPeriodIntegrity([{
+        date: "2024-12-31",
+        period: "FY",
+        fiscal_year: "2024",
+        filing_date: "2025-01-15",
+        accepted_date: "2025-01-01T12:00:00.000Z",
+      }], now);
+
+      expect(findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          severity: "warning",
+          sourceReference: "accepted-before-filing",
+          evidence: expect.objectContaining({ graceDays: 7 }),
+        }),
+      ]));
+    });
+
     it("detects multiple dates mapped to one fiscal period", () => {
       const findings = validateReportingPeriodIntegrity(
         [

--- a/supabase/functions/_shared/data-quality-validation.ts
+++ b/supabase/functions/_shared/data-quality-validation.ts
@@ -32,6 +32,10 @@ const BALANCE_CRITICAL_THRESHOLD = 0.05;
 const MARKET_CAP_WARNING_THRESHOLD = 0.05;
 const MARKET_CAP_CRITICAL_THRESHOLD = 0.20;
 const FUTURE_PERIOD_GRACE_DAYS = 7;
+// EDGAR generally assigns the next business day's filing date to submissions
+// accepted after 5:30 p.m. ET. Weekends and holidays can therefore make a
+// valid acceptance timestamp precede filing_date by several calendar days.
+const ACCEPTED_BEFORE_FILING_GRACE_DAYS = 7;
 
 function finiteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
@@ -327,16 +331,25 @@ export function validateReportingPeriodIntegrity(
         sourcePeriod,
         sourceReference: "invalid-accepted-date",
       });
-    } else if (acceptedDate && filingDate && acceptedDate < filingDate) {
+    } else if (
+      acceptedDate &&
+      filingDate &&
+      filingDate.getTime() - acceptedDate.getTime() >
+        ACCEPTED_BEFORE_FILING_GRACE_DAYS * 86_400_000
+    ) {
+      const acceptedBeforeFilingDays =
+        (filingDate.getTime() - acceptedDate.getTime()) / 86_400_000;
       findings.push({
         checkCode: "reporting_period_integrity",
         fieldName: "accepted_date",
         severity: "warning",
         message:
-          "Financial statement acceptance timestamp precedes its filing date.",
+          "Financial statement acceptance timestamp materially precedes its filing date.",
         evidence: {
           filingDate: statement.filing_date,
           acceptedDate: statement.accepted_date,
+          acceptedBeforeFilingDays,
+          graceDays: ACCEPTED_BEFORE_FILING_GRACE_DAYS,
         },
         sourceDate,
         sourcePeriod,


### PR DESCRIPTION
Accounts for EDGAR’s next-business-day filing-date rules when validating acceptance timestamps. Prevents normal after-hours, weekend, and holiday filings from being reported as integrity problems while retaining warnings for materially earlier timestamps. A zero-FMP production sample fell from 156 findings to 29, eliminating 127 false positives.