### PR TITLE
Flag empty exchange variant responses

### DIFF
--- a/supabase/functions/__tests__/exchange-variants-data-quality.test.ts
+++ b/supabase/functions/__tests__/exchange-variants-data-quality.test.ts
@@ -1,0 +1,232 @@
+import {
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { QueueJob } from "../lib/types.ts";
+
+Deno.env.set("FMP_API_KEY", "exchange-variants-quality-test-key");
+
+const { fetchExchangeVariantsLogic } = await import(
+  "../lib/fetch-fmp-exchange-variants.ts?exchange-variants-quality-test"
+);
+
+interface RpcCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+const job: QueueJob = {
+  id: "job-exchange-variants",
+  symbol: "TEST",
+  data_type: "exchange-variants",
+  status: "processing",
+  priority: -1,
+  retry_count: 0,
+  max_retries: 3,
+  created_at: "2026-08-01T00:00:00Z",
+  estimated_data_size_bytes: 1,
+  job_metadata: {},
+};
+
+function profileChain() {
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    maybeSingle: () =>
+      Promise.resolve({
+        data: {
+          price: 10,
+          beta: 1,
+          average_volume: 1_000,
+          market_cap: 1_000_000,
+          last_dividend: 0,
+          range: "9-11",
+          change: 0.1,
+          currency: "USD",
+          cik: "0000000001",
+          isin: null,
+          cusip: null,
+          exchange: "NASDAQ",
+          image: null,
+          ipo_date: "2020-01-01",
+          default_image: true,
+          is_actively_trading: true,
+        },
+        error: null,
+      }),
+  };
+  return chain;
+}
+
+function exchangeVariantsChain(existing = false) {
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    in: () => chain,
+    maybeSingle: () =>
+      Promise.resolve({
+        data: existing
+          ? { symbol_variant: "TEST", exchange_short_name: "NASDAQ" }
+          : null,
+        error: null,
+      }),
+    upsert: () => Promise.resolve({ error: null }),
+    update: () => chain,
+  };
+  return chain;
+}
+
+Deno.test(
+  "empty exchange-variants response records a quality issue before using the fallback",
+  async () => {
+    const originalFetch = globalThis.fetch;
+    const rpcCalls: RpcCall[] = [];
+    try {
+      globalThis.fetch = () =>
+        Promise.resolve(
+          new Response("[]", {
+            status: 200,
+            headers: { "Content-Length": "2" },
+          }),
+        );
+      const supabase = {
+        rpc: (name: string, args: Record<string, unknown>) => {
+          rpcCalls.push({ name, args });
+          return Promise.resolve({ error: null });
+        },
+        from: (table: string) => {
+          if (table === "profiles") return profileChain();
+          if (table === "exchange_variants") return exchangeVariantsChain();
+          throw new Error(`Unexpected table access: ${table}`);
+        },
+      } as unknown as SupabaseClient;
+
+      const result = await fetchExchangeVariantsLogic(job, supabase);
+
+      assertEquals(result, { success: true, dataSizeBytes: 2 });
+      assertEquals(rpcCalls.map((call) => call.name), [
+        "record_data_quality_issue_v2",
+      ]);
+      assertEquals(
+        rpcCalls[0].args.p_check_code,
+        "empty_exchange_variants_response",
+      );
+      assertEquals(rpcCalls[0].args.p_severity, "warning");
+      const evidence = rpcCalls[0].args.p_evidence as Record<string, unknown>;
+      assertEquals(evidence.response_count, 0);
+      assertEquals(
+        evidence.endpoint_url,
+        "https://financialmodelingprep.com/stable/search-exchange-variants?symbol=TEST",
+      );
+      assertExists(evidence.queue_job_id);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);
+
+Deno.test(
+  "non-empty exchange-variants response resolves the specific empty-response issue",
+  async () => {
+    const originalFetch = globalThis.fetch;
+    const rpcCalls: RpcCall[] = [];
+    try {
+      globalThis.fetch = () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify([{
+              symbol: "TEST",
+              exchangeShortName: "NASDAQ",
+              price: 10,
+              beta: 1,
+              volAvg: 1_000,
+              mktCap: 1_000_000,
+              lastDiv: 0,
+              range: "9-11",
+              changes: 0.1,
+              currency: "USD",
+              cik: "0000000001",
+              isin: null,
+              cusip: null,
+              exchange: "NASDAQ",
+              dcfDiff: null,
+              dcf: null,
+              image: null,
+              ipoDate: "2020-01-01",
+              defaultImage: true,
+              isActivelyTrading: true,
+            }]),
+            {
+              status: 200,
+              headers: { "Content-Length": "100" },
+            },
+          ),
+        );
+      const supabase = {
+        rpc: (name: string, args: Record<string, unknown>) => {
+          rpcCalls.push({ name, args });
+          return Promise.resolve({ error: null });
+        },
+        from: (table: string) => {
+          if (table === "exchange_variants") return exchangeVariantsChain();
+          throw new Error(`Unexpected table access: ${table}`);
+        },
+      } as unknown as SupabaseClient;
+
+      const result = await fetchExchangeVariantsLogic(job, supabase);
+
+      assertEquals(result, { success: true, dataSizeBytes: 100 });
+      assertEquals(rpcCalls.map((call) => call.name), [
+        "resolve_data_quality_issue_v2",
+      ]);
+      assertEquals(rpcCalls[0].args, {
+        p_symbol: "TEST",
+        p_provider: "fmp",
+        p_endpoint: "exchange-variants",
+        p_check_code: "empty_exchange_variants_response",
+        p_field_name: "symbol_variant",
+        p_source_date: null,
+        p_source_period: null,
+        p_source_reference: "empty-response",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);
+
+Deno.test(
+  "empty response fails closed when its quality issue cannot be recorded",
+  async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = () =>
+        Promise.resolve(
+          new Response("[]", {
+            status: 200,
+            headers: { "Content-Length": "2" },
+          }),
+        );
+      const supabase = {
+        rpc: () =>
+          Promise.resolve({ error: { message: "quality store unavailable" } }),
+        from: (table: string) => {
+          throw new Error(
+            `Unexpected fallback write after RPC failure: ${table}`,
+          );
+        },
+      } as unknown as SupabaseClient;
+
+      const result = await fetchExchangeVariantsLogic(job, supabase);
+
+      assertEquals(result.success, false);
+      assertEquals(
+        result.error,
+        "Failed to record empty exchange-variants response for TEST: quality store unavailable",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);

--- a/supabase/functions/lib/exchange-variants-quality.ts
+++ b/supabase/functions/lib/exchange-variants-quality.ts
@@ -1,0 +1,73 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { QueueJob } from "./types.ts";
+
+const PROVIDER = "fmp";
+const ENDPOINT = "exchange-variants";
+const CHECK_CODE = "empty_exchange_variants_response";
+const FIELD_NAME = "symbol_variant";
+const SOURCE_REFERENCE = "empty-response";
+const FMP_ENDPOINT_URL =
+  "https://financialmodelingprep.com/stable/search-exchange-variants";
+
+export async function recordEmptyExchangeVariantsResponse(
+  supabase: SupabaseClient,
+  job: QueueJob,
+  responseSizeBytes: number,
+): Promise<void> {
+  const validationUrl = `${FMP_ENDPOINT_URL}?symbol=${
+    encodeURIComponent(job.symbol)
+  }`;
+  const { error } = await supabase.rpc("record_data_quality_issue_v2", {
+    p_symbol: job.symbol,
+    p_provider: PROVIDER,
+    p_endpoint: ENDPOINT,
+    p_check_code: CHECK_CODE,
+    p_severity: "warning",
+    p_message:
+      "FMP returned an empty exchange-variants array for a listed symbol; a profile-derived fallback was used for display continuity.",
+    p_evidence: {
+      response_count: 0,
+      response_size_bytes: responseSizeBytes,
+      endpoint_url: validationUrl,
+      queue_job_id: job.id,
+      retry_count: job.retry_count,
+      max_retries: job.max_retries,
+      fallback_strategy: "profile-derived-sentinel",
+    },
+    p_field_name: FIELD_NAME,
+    p_source_date: null,
+    p_source_period: null,
+    p_source_reference: SOURCE_REFERENCE,
+  });
+
+  if (error) {
+    throw new Error(
+      `Failed to record empty exchange-variants response for ${job.symbol}: ${error.message}`,
+    );
+  }
+}
+
+export async function resolveEmptyExchangeVariantsResponse(
+  supabase: SupabaseClient,
+  symbol: string,
+): Promise<boolean> {
+  const { error } = await supabase.rpc("resolve_data_quality_issue_v2", {
+    p_symbol: symbol,
+    p_provider: PROVIDER,
+    p_endpoint: ENDPOINT,
+    p_check_code: CHECK_CODE,
+    p_field_name: FIELD_NAME,
+    p_source_date: null,
+    p_source_period: null,
+    p_source_reference: SOURCE_REFERENCE,
+  });
+
+  if (error) {
+    console.error(
+      `[data-quality] Failed to resolve empty exchange-variants response for ${symbol}: ${error.message}`,
+    );
+    return false;
+  }
+
+  return true;
+}

--- a/supabase/functions/lib/fetch-fmp-exchange-variants.ts
+++ b/supabase/functions/lib/fetch-fmp-exchange-variants.ts
@@ -10,6 +10,10 @@ import type {
   FmpExchangeVariantData,
   SupabaseExchangeVariantRecord,
 } from '../fetch-fmp-exchange-variants/types.ts';
+import {
+  recordEmptyExchangeVariantsResponse,
+  resolveEmptyExchangeVariantsResponse,
+} from './exchange-variants-quality.ts';
 
 const FMP_API_KEY = Deno.env.get('FMP_API_KEY');
 const FMP_EXCHANGE_VARIANTS_BASE_URL = 'https://financialmodelingprep.com/stable/search-exchange-variants';
@@ -70,6 +74,15 @@ export async function fetchExchangeVariantsLogic(
     }
 
     if (fmpVariantsResult.length === 0) {
+      // An empty array is not valid exchange coverage for a listed symbol.
+      // Persist the upstream anomaly before creating the profile-derived
+      // sentinel, so the rendering fallback cannot mask the quality issue.
+      await recordEmptyExchangeVariantsResponse(
+        supabase,
+        job,
+        actualSizeBytes,
+      );
+
       // CRITICAL: Create a sentinel record for exchange-variants if FMP returns empty array
       // This prevents infinite retries for symbols that genuinely have no exchange variants
       // CRITICAL: The sentinel record uses the actual symbol as symbol_variant (not a sentinel value)
@@ -261,6 +274,10 @@ export async function fetchExchangeVariantsLogic(
 
     }
 
+    // A successfully persisted non-empty response clears only the matching
+    // empty-response anomaly. Other exchange-variant findings remain open.
+    await resolveEmptyExchangeVariantsResponse(supabase, job.symbol);
+
     return {
       success: true,
       dataSizeBytes: actualSizeBytes,
@@ -273,4 +290,3 @@ export async function fetchExchangeVariantsLogic(
     };
   }
 }
-


### PR DESCRIPTION
Empty exchange-variant responses now:

- Open empty_exchange_variants_response in data_quality_issues.
- Include a key-free FMP validation URL and queue evidence.
- Retain the profile sentinel only as a UI fallback.
- Resolve automatically after a valid response.
- Fail closed if the issue cannot be recorded.