### PR TITLE
Gate exchange variant replacements on quality

### DIFF
--- a/scripts/security/verify-exchange-variant-quality-gate.sql
+++ b/scripts/security/verify-exchange-variant-quality-gate.sql
@@ -1,0 +1,121 @@
+BEGIN;
+
+INSERT INTO public.profiles (symbol, exchange, is_actively_trading)
+VALUES ('QAVX', 'NASDAQ', true)
+ON CONFLICT (symbol) DO NOTHING;
+
+INSERT INTO public.exchange_variants (
+  symbol,
+  symbol_variant,
+  exchange_short_name,
+  is_actively_trading
+)
+VALUES
+  ('QAVX', 'QAVX', 'NASDAQ', true),
+  ('QAVX', 'QAVX.DE', 'XETRA', true)
+ON CONFLICT (symbol_variant, exchange_short_name) DO UPDATE
+SET symbol = EXCLUDED.symbol;
+
+DO $$
+DECLARE
+  replaced integer;
+BEGIN
+  SELECT public.replace_exchange_variants_v2(
+    'QAVX',
+    '[{
+      "symbol": "QAVX",
+      "symbol_variant": "QAVX",
+      "exchange_short_name": "NASDAQ",
+      "price": 10,
+      "is_actively_trading": true
+    }]'::jsonb
+  ) INTO replaced;
+
+  IF replaced <> 1 THEN
+    RAISE EXCEPTION 'expected one replacement row, got %', replaced;
+  END IF;
+  IF (SELECT count(*) FROM public.exchange_variants WHERE symbol = 'QAVX') <> 1
+     OR EXISTS (
+       SELECT 1
+       FROM public.exchange_variants
+       WHERE symbol = 'QAVX'
+         AND symbol_variant = 'QAVX.DE'
+     )
+  THEN
+    RAISE EXCEPTION 'validated replacement did not remove the obsolete row';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  BEGIN
+    PERFORM public.replace_exchange_variants_v2('QAVX', '[]'::jsonb);
+    RAISE EXCEPTION 'empty replacement unexpectedly succeeded';
+  EXCEPTION
+    WHEN OTHERS THEN
+      IF SQLERRM = 'empty replacement unexpectedly succeeded' THEN
+        RAISE;
+      END IF;
+  END;
+
+  IF (SELECT count(*) FROM public.exchange_variants WHERE symbol = 'QAVX') <> 1
+  THEN
+    RAISE EXCEPTION 'empty replacement changed the last-known-good set';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  BEGIN
+    PERFORM public.replace_exchange_variants_v2(
+      'QAVX',
+      '[
+        {
+          "symbol": "QAVX",
+          "symbol_variant": "QAVX",
+          "exchange_short_name": "NASDAQ"
+        },
+        {
+          "symbol": "QAVX",
+          "symbol_variant": "QAVX",
+          "exchange_short_name": "NASDAQ"
+        }
+      ]'::jsonb
+    );
+    RAISE EXCEPTION 'duplicate replacement unexpectedly succeeded';
+  EXCEPTION
+    WHEN OTHERS THEN
+      IF SQLERRM = 'duplicate replacement unexpectedly succeeded' THEN
+        RAISE;
+      END IF;
+  END;
+
+  IF (SELECT count(*) FROM public.exchange_variants WHERE symbol = 'QAVX') <> 1
+  THEN
+    RAISE EXCEPTION 'duplicate replacement changed the last-known-good set';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF has_function_privilege(
+    'anon',
+    'public.replace_exchange_variants_v2(text,jsonb)',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'anon must not execute replace_exchange_variants_v2';
+  END IF;
+  IF NOT has_function_privilege(
+    'service_role',
+    'public.replace_exchange_variants_v2(text,jsonb)',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'service_role must execute replace_exchange_variants_v2';
+  END IF;
+END;
+$$;
+
+ROLLBACK;

--- a/supabase/functions/__tests__/exchange-variants-data-quality.test.ts
+++ b/supabase/functions/__tests__/exchange-variants-data-quality.test.ts
@@ -4,11 +4,12 @@ import {
 } from "https://deno.land/std@0.208.0/assert/mod.ts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { QueueJob } from "../lib/types.ts";
+import { validateExchangeVariantsResponse } from "../lib/exchange-variants-quality.ts";
 
 Deno.env.set("FMP_API_KEY", "exchange-variants-quality-test-key");
 
 const { fetchExchangeVariantsLogic } = await import(
-  "../lib/fetch-fmp-exchange-variants.ts?exchange-variants-quality-test"
+  "../lib/fetch-fmp-exchange-variants.ts?exchange-variants-quality-gate-test"
 );
 
 interface RpcCall {
@@ -29,204 +30,272 @@ const job: QueueJob = {
   job_metadata: {},
 };
 
-function profileChain() {
-  const chain = {
-    select: () => chain,
-    eq: () => chain,
-    maybeSingle: () =>
-      Promise.resolve({
-        data: {
-          price: 10,
-          beta: 1,
-          average_volume: 1_000,
-          market_cap: 1_000_000,
-          last_dividend: 0,
-          range: "9-11",
-          change: 0.1,
-          currency: "USD",
-          cik: "0000000001",
-          isin: null,
-          cusip: null,
-          exchange: "NASDAQ",
-          image: null,
-          ipo_date: "2020-01-01",
-          default_image: true,
-          is_actively_trading: true,
-        },
-        error: null,
-      }),
-  };
-  return chain;
+const baseVariant = {
+  symbol: "TEST",
+  exchangeShortName: "NASDAQ",
+  price: 10,
+  beta: 1,
+  volAvg: 1_000,
+  mktCap: 1_000_000,
+  lastDiv: 0,
+  range: "9-11",
+  changes: 0.1,
+  currency: "USD",
+  cik: "0000000001",
+  isin: null,
+  cusip: null,
+  exchange: "NASDAQ",
+  dcfDiff: null,
+  dcf: null,
+  image: null,
+  ipoDate: "2020-01-01",
+  defaultImage: true,
+  isActivelyTrading: true,
+};
+
+const xetraVariant = {
+  ...baseVariant,
+  symbol: "TEST.DE",
+  exchangeShortName: "XETRA",
+  currency: "EUR",
+};
+
+function mockClient(options: {
+  existing?: Array<{
+    symbol_variant: string;
+    exchange_short_name: string;
+    is_actively_trading: boolean | null;
+  }>;
+  exchanges?: string[];
+  profile?: { exchange: string } | null;
+  syncError?: string;
+}) {
+  const rpcCalls: RpcCall[] = [];
+  const fromCalls: string[] = [];
+  const supabase = {
+    rpc: (name: string, args: Record<string, unknown>) => {
+      rpcCalls.push({ name, args });
+      return Promise.resolve({
+        data: name === "replace_exchange_variants_v2" ? 2 : null,
+        error: name === "sync_data_quality_issues" && options.syncError
+          ? { message: options.syncError }
+          : null,
+      });
+    },
+    from: (table: string) => {
+      fromCalls.push(table);
+      if (table === "profiles") {
+        const chain = {
+          select: () => chain,
+          eq: () => chain,
+          maybeSingle: () =>
+            Promise.resolve({ data: options.profile ?? null, error: null }),
+        };
+        return chain;
+      }
+      if (table === "exchange_variants") {
+        const chain = {
+          select: () => chain,
+          eq: () =>
+            Promise.resolve({ data: options.existing ?? [], error: null }),
+        };
+        return chain;
+      }
+      if (table === "available_exchanges") {
+        return {
+          select: () =>
+            Promise.resolve({
+              data: (options.exchanges ?? []).map((exchange) => ({ exchange })),
+              error: null,
+            }),
+        };
+      }
+      throw new Error(`Unexpected table access: ${table}`);
+    },
+  } as unknown as SupabaseClient;
+
+  return { supabase, rpcCalls, fromCalls };
 }
 
-function exchangeVariantsChain(existing = false) {
-  const chain = {
-    select: () => chain,
-    eq: () => chain,
-    in: () => chain,
-    maybeSingle: () =>
-      Promise.resolve({
-        data: existing
-          ? { symbol_variant: "TEST", exchange_short_name: "NASDAQ" }
-          : null,
-        error: null,
-      }),
-    upsert: () => Promise.resolve({ error: null }),
-    update: () => chain,
-  };
-  return chain;
+async function withFmpResponse(
+  payload: unknown,
+  callback: () => Promise<void>,
+) {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = () =>
+      Promise.resolve(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { "Content-Length": "100" },
+        }),
+      );
+    await callback();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 }
 
 Deno.test(
-  "empty exchange-variants response records a quality issue before using the fallback",
+  "empty response is recorded, rejected, and never writes a sentinel",
   async () => {
-    const originalFetch = globalThis.fetch;
-    const rpcCalls: RpcCall[] = [];
-    try {
-      globalThis.fetch = () =>
-        Promise.resolve(
-          new Response("[]", {
-            status: 200,
-            headers: { "Content-Length": "2" },
-          }),
-        );
-      const supabase = {
-        rpc: (name: string, args: Record<string, unknown>) => {
-          rpcCalls.push({ name, args });
-          return Promise.resolve({ error: null });
-        },
-        from: (table: string) => {
-          if (table === "profiles") return profileChain();
-          if (table === "exchange_variants") return exchangeVariantsChain();
-          throw new Error(`Unexpected table access: ${table}`);
-        },
-      } as unknown as SupabaseClient;
-
+    await withFmpResponse([], async () => {
+      const { supabase, rpcCalls, fromCalls } = mockClient({});
       const result = await fetchExchangeVariantsLogic(job, supabase);
 
-      assertEquals(result, { success: true, dataSizeBytes: 2 });
+      assertEquals(result.success, false);
+      assertEquals(result.dataSizeBytes, 100);
+      assertEquals(fromCalls, []);
       assertEquals(rpcCalls.map((call) => call.name), [
-        "record_data_quality_issue_v2",
+        "sync_data_quality_issues",
       ]);
-      assertEquals(
-        rpcCalls[0].args.p_check_code,
-        "empty_exchange_variants_response",
+      const findings = rpcCalls[0].args.p_findings as Array<
+        Record<string, unknown>
+      >;
+      assertEquals(findings[0].check_code, "empty_exchange_variants_response");
+      assertEquals(findings[0].severity, "critical");
+      assertEquals(findings[0].source_reference, "empty-response");
+      assertExists(
+        (findings[0].evidence as Record<string, unknown>).endpointUrl,
       );
-      assertEquals(rpcCalls[0].args.p_severity, "warning");
-      const evidence = rpcCalls[0].args.p_evidence as Record<string, unknown>;
-      assertEquals(evidence.response_count, 0);
-      assertEquals(
-        evidence.endpoint_url,
-        "https://financialmodelingprep.com/stable/search-exchange-variants?symbol=TEST",
-      );
-      assertExists(evidence.queue_job_id);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    });
   },
 );
 
 Deno.test(
-  "non-empty exchange-variants response resolves the specific empty-response issue",
+  "validated complete response is atomically replaced and clears findings",
   async () => {
-    const originalFetch = globalThis.fetch;
-    const rpcCalls: RpcCall[] = [];
-    try {
-      globalThis.fetch = () =>
-        Promise.resolve(
-          new Response(
-            JSON.stringify([{
-              symbol: "TEST",
-              exchangeShortName: "NASDAQ",
-              price: 10,
-              beta: 1,
-              volAvg: 1_000,
-              mktCap: 1_000_000,
-              lastDiv: 0,
-              range: "9-11",
-              changes: 0.1,
-              currency: "USD",
-              cik: "0000000001",
-              isin: null,
-              cusip: null,
-              exchange: "NASDAQ",
-              dcfDiff: null,
-              dcf: null,
-              image: null,
-              ipoDate: "2020-01-01",
-              defaultImage: true,
-              isActivelyTrading: true,
-            }]),
-            {
-              status: 200,
-              headers: { "Content-Length": "100" },
-            },
-          ),
-        );
-      const supabase = {
-        rpc: (name: string, args: Record<string, unknown>) => {
-          rpcCalls.push({ name, args });
-          return Promise.resolve({ error: null });
-        },
-        from: (table: string) => {
-          if (table === "exchange_variants") return exchangeVariantsChain();
-          throw new Error(`Unexpected table access: ${table}`);
-        },
-      } as unknown as SupabaseClient;
-
+    await withFmpResponse([baseVariant, xetraVariant], async () => {
+      const { supabase, rpcCalls } = mockClient({
+        profile: { exchange: "NASDAQ" },
+        exchanges: ["NASDAQ", "XETRA"],
+        existing: [
+          {
+            symbol_variant: "TEST",
+            exchange_short_name: "NASDAQ",
+            is_actively_trading: true,
+          },
+          {
+            symbol_variant: "TEST.DE",
+            exchange_short_name: "XETRA",
+            is_actively_trading: true,
+          },
+        ],
+      });
       const result = await fetchExchangeVariantsLogic(job, supabase);
 
       assertEquals(result, { success: true, dataSizeBytes: 100 });
       assertEquals(rpcCalls.map((call) => call.name), [
-        "resolve_data_quality_issue_v2",
+        "replace_exchange_variants_v2",
+        "sync_data_quality_issues",
       ]);
-      assertEquals(rpcCalls[0].args, {
-        p_symbol: "TEST",
-        p_provider: "fmp",
-        p_endpoint: "exchange-variants",
-        p_check_code: "empty_exchange_variants_response",
-        p_field_name: "symbol_variant",
-        p_source_date: null,
-        p_source_period: null,
-        p_source_reference: "empty-response",
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+      assertEquals(
+        (rpcCalls[0].args.p_records as unknown[]).length,
+        2,
+      );
+      assertEquals(rpcCalls[1].args.p_findings, []);
+    });
   },
 );
 
 Deno.test(
-  "empty response fails closed when its quality issue cannot be recorded",
+  "missing previously active variant is recorded and preserves stored data",
   async () => {
-    const originalFetch = globalThis.fetch;
-    try {
-      globalThis.fetch = () =>
-        Promise.resolve(
-          new Response("[]", {
-            status: 200,
-            headers: { "Content-Length": "2" },
-          }),
-        );
-      const supabase = {
-        rpc: () =>
-          Promise.resolve({ error: { message: "quality store unavailable" } }),
-        from: (table: string) => {
-          throw new Error(
-            `Unexpected fallback write after RPC failure: ${table}`,
-          );
-        },
-      } as unknown as SupabaseClient;
-
+    await withFmpResponse([baseVariant], async () => {
+      const { supabase, rpcCalls } = mockClient({
+        profile: { exchange: "NASDAQ" },
+        exchanges: ["NASDAQ", "XETRA"],
+        existing: [
+          {
+            symbol_variant: "TEST",
+            exchange_short_name: "NASDAQ",
+            is_actively_trading: true,
+          },
+          {
+            symbol_variant: "TEST.DE",
+            exchange_short_name: "XETRA",
+            is_actively_trading: true,
+          },
+        ],
+      });
       const result = await fetchExchangeVariantsLogic(job, supabase);
 
       assertEquals(result.success, false);
+      assertEquals(rpcCalls.map((call) => call.name), [
+        "sync_data_quality_issues",
+      ]);
+      const findings = rpcCalls[0].args.p_findings as Array<
+        Record<string, unknown>
+      >;
       assertEquals(
-        result.error,
-        "Failed to record empty exchange-variants response for TEST: quality store unavailable",
+        findings.some((finding) =>
+          finding.check_code === "exchange_variant_set_regression"
+        ),
+        true,
       );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    });
   },
 );
+
+Deno.test(
+  "quality failure never replaces data when issue persistence fails",
+  async () => {
+    await withFmpResponse([baseVariant], async () => {
+      const { supabase, rpcCalls } = mockClient({
+        profile: { exchange: "NASDAQ" },
+        exchanges: ["NASDAQ", "XETRA"],
+        existing: [
+          {
+            symbol_variant: "TEST.DE",
+            exchange_short_name: "XETRA",
+            is_actively_trading: true,
+          },
+        ],
+        syncError: "persistence unavailable",
+      });
+      const result = await fetchExchangeVariantsLogic(job, supabase);
+
+      assertEquals(result.success, false);
+      assertEquals(result.dataSizeBytes, 100);
+      assertEquals(result.error?.includes("Failed to synchronize"), true);
+      assertEquals(rpcCalls.map((call) => call.name), [
+        "sync_data_quality_issues",
+      ]);
+    });
+  },
+);
+
+Deno.test("validator rejects incomplete and unknown exchange data", () => {
+  const findings = validateExchangeVariantsResponse({
+    symbol: "TEST",
+    response: [{
+      symbol: "OTHER",
+      exchangeShortName: "UNKNOWN",
+    }],
+    profileExchange: "NASDAQ",
+    profileExists: true,
+    knownExchanges: ["NASDAQ"],
+    existingVariants: [],
+  });
+
+  assertEquals(
+    findings.map((finding) => finding.checkCode).sort(),
+    ["exchange_variants_base_listing", "exchange_variants_exchange_code"],
+  );
+});
+
+Deno.test("validator flags duplicate records and a base-exchange mismatch", () => {
+  const findings = validateExchangeVariantsResponse({
+    symbol: "TEST",
+    response: [baseVariant, xetraVariant, xetraVariant],
+    profileExchange: "NYSE",
+    profileExists: true,
+    knownExchanges: ["NASDAQ", "NYSE", "XETRA"],
+    existingVariants: [],
+  });
+
+  assertEquals(
+    findings.map((finding) => finding.sourceReference).sort(),
+    ["duplicate-records", "profile-exchange-mismatch"],
+  );
+});

--- a/supabase/functions/lib/exchange-variants-quality.ts
+++ b/supabase/functions/lib/exchange-variants-quality.ts
@@ -1,73 +1,247 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import type { DataQualityFinding } from "../_shared/data-quality-validation.ts";
+import { syncDataQualityFindings } from "../_shared/data-quality-persistence.ts";
 import type { QueueJob } from "./types.ts";
 
-const PROVIDER = "fmp";
-const ENDPOINT = "exchange-variants";
-const CHECK_CODE = "empty_exchange_variants_response";
-const FIELD_NAME = "symbol_variant";
-const SOURCE_REFERENCE = "empty-response";
 const FMP_ENDPOINT_URL =
   "https://financialmodelingprep.com/stable/search-exchange-variants";
 
-export async function recordEmptyExchangeVariantsResponse(
-  supabase: SupabaseClient,
-  job: QueueJob,
-  responseSizeBytes: number,
-): Promise<void> {
-  const validationUrl = `${FMP_ENDPOINT_URL}?symbol=${
-    encodeURIComponent(job.symbol)
-  }`;
-  const { error } = await supabase.rpc("record_data_quality_issue_v2", {
-    p_symbol: job.symbol,
-    p_provider: PROVIDER,
-    p_endpoint: ENDPOINT,
-    p_check_code: CHECK_CODE,
-    p_severity: "warning",
-    p_message:
-      "FMP returned an empty exchange-variants array for a listed symbol; a profile-derived fallback was used for display continuity.",
-    p_evidence: {
-      response_count: 0,
-      response_size_bytes: responseSizeBytes,
-      endpoint_url: validationUrl,
-      queue_job_id: job.id,
-      retry_count: job.retry_count,
-      max_retries: job.max_retries,
-      fallback_strategy: "profile-derived-sentinel",
-    },
-    p_field_name: FIELD_NAME,
-    p_source_date: null,
-    p_source_period: null,
-    p_source_reference: SOURCE_REFERENCE,
-  });
-
-  if (error) {
-    throw new Error(
-      `Failed to record empty exchange-variants response for ${job.symbol}: ${error.message}`,
-    );
-  }
+interface ExistingExchangeVariant {
+  symbol_variant: string;
+  exchange_short_name: string;
+  is_actively_trading: boolean | null;
 }
 
-export async function resolveEmptyExchangeVariantsResponse(
-  supabase: SupabaseClient,
-  symbol: string,
-): Promise<boolean> {
-  const { error } = await supabase.rpc("resolve_data_quality_issue_v2", {
-    p_symbol: symbol,
-    p_provider: PROVIDER,
-    p_endpoint: ENDPOINT,
-    p_check_code: CHECK_CODE,
-    p_field_name: FIELD_NAME,
-    p_source_date: null,
-    p_source_period: null,
-    p_source_reference: SOURCE_REFERENCE,
-  });
+interface ExchangeVariantQualityContext {
+  symbol: string;
+  response: unknown[];
+  profileExchange: string | null;
+  profileExists: boolean;
+  knownExchanges: string[];
+  existingVariants: ExistingExchangeVariant[];
+}
 
-  if (error) {
-    console.error(
-      `[data-quality] Failed to resolve empty exchange-variants response for ${symbol}: ${error.message}`,
-    );
-    return false;
+function normalized(value: unknown): string | null {
+  return typeof value === "string" && value.trim()
+    ? value.trim().toUpperCase()
+    : null;
+}
+
+function canonicalExchange(value: unknown): string | null {
+  const exchange = normalized(value);
+  if (exchange === "PNK" || exchange === "OTCQX" || exchange === "OTCQB") {
+    return "OTC";
+  }
+  return exchange;
+}
+
+function variantKey(symbol: unknown, exchange: unknown): string | null {
+  const normalizedSymbol = normalized(symbol);
+  const normalizedExchange = normalized(exchange);
+  return normalizedSymbol && normalizedExchange
+    ? `${normalizedSymbol}|${normalizedExchange}`
+    : null;
+}
+
+export function validateExchangeVariantsResponse(
+  context: ExchangeVariantQualityContext,
+): DataQualityFinding[] {
+  const baseSymbol = normalized(context.symbol) ?? context.symbol;
+
+  if (context.response.length === 0) {
+    return [{
+      checkCode: "empty_exchange_variants_response",
+      fieldName: "symbol_variant",
+      severity: "critical",
+      message:
+        "FMP returned an empty exchange-variants array for a listed symbol.",
+      evidence: { responseCount: 0 },
+      sourceReference: "empty-response",
+    }];
   }
 
-  return true;
+  const findings: DataQualityFinding[] = [];
+  const malformedIndexes: number[] = [];
+  const incomingKeys = new Set<string>();
+  const duplicateKeys = new Set<string>();
+  const responseEntries: Array<Record<string, unknown>> = [];
+
+  context.response.forEach((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      malformedIndexes.push(index);
+      return;
+    }
+    const record = entry as Record<string, unknown>;
+    const key = variantKey(record.symbol, record.exchangeShortName);
+    if (!key) {
+      malformedIndexes.push(index);
+      return;
+    }
+    if (incomingKeys.has(key)) duplicateKeys.add(key);
+    incomingKeys.add(key);
+    responseEntries.push(record);
+  });
+
+  if (malformedIndexes.length > 0) {
+    findings.push({
+      checkCode: "exchange_variants_payload_integrity",
+      fieldName: "symbol_variant",
+      severity: "critical",
+      message:
+        "FMP returned exchange-variant records without a usable symbol and exchange code.",
+      evidence: { malformedIndexes, responseCount: context.response.length },
+      sourceReference: "malformed-records",
+    });
+  }
+
+  if (duplicateKeys.size > 0) {
+    findings.push({
+      checkCode: "exchange_variants_payload_integrity",
+      fieldName: "symbol_variant",
+      severity: "critical",
+      message: "FMP returned duplicate exchange-variant records.",
+      evidence: { duplicateKeys: [...duplicateKeys].sort() },
+      sourceReference: "duplicate-records",
+    });
+  }
+
+  const knownExchanges = new Set(
+    context.knownExchanges.map(canonicalExchange).filter(
+      (exchange): exchange is string => exchange !== null,
+    ),
+  );
+  const unknownExchanges = new Set(
+    responseEntries
+      .map((entry) => canonicalExchange(entry.exchangeShortName))
+      .filter(
+        (exchange): exchange is string =>
+          exchange !== null && !knownExchanges.has(exchange),
+      ),
+  );
+  if (unknownExchanges.size > 0) {
+    findings.push({
+      checkCode: "exchange_variants_exchange_code",
+      fieldName: "exchange_short_name",
+      severity: "warning",
+      message:
+        "FMP returned exchange codes absent from the available-exchanges registry.",
+      evidence: { unknownExchanges: [...unknownExchanges].sort() },
+      sourceReference: "unknown-exchange-codes",
+    });
+  }
+
+  const baseEntries = responseEntries.filter(
+    (entry) => normalized(entry.symbol) === baseSymbol,
+  );
+  if (baseEntries.length !== 1) {
+    findings.push({
+      checkCode: "exchange_variants_base_listing",
+      fieldName: "symbol_variant",
+      severity: "critical",
+      message: baseEntries.length === 0
+        ? "FMP exchange variants omitted the requested symbol's base listing."
+        : "FMP exchange variants returned multiple base listings for the requested symbol.",
+      evidence: {
+        baseSymbol,
+        baseEntryCount: baseEntries.length,
+        baseExchanges: baseEntries.map((entry) => entry.exchangeShortName),
+      },
+      sourceReference: baseEntries.length === 0
+        ? "missing-base-listing"
+        : "multiple-base-listings",
+    });
+  }
+
+  if (!context.profileExists) {
+    findings.push({
+      checkCode: "exchange_variants_primary_exchange",
+      fieldName: "symbol",
+      severity: "critical",
+      message:
+        "The exchange-variants response cannot be validated because the symbol profile is missing.",
+      evidence: { baseSymbol },
+      sourceReference: "missing-profile",
+    });
+  } else if (!context.profileExchange) {
+    findings.push({
+      checkCode: "exchange_variants_primary_exchange",
+      fieldName: "exchange_short_name",
+      severity: "critical",
+      message:
+        "The exchange-variants response cannot be validated because the profile exchange is missing.",
+      evidence: { baseSymbol },
+      sourceReference: "missing-profile-exchange",
+    });
+  } else if (baseEntries.length === 1 && context.profileExchange) {
+    const responseExchange = canonicalExchange(
+      baseEntries[0].exchangeShortName,
+    );
+    const profileExchange = canonicalExchange(context.profileExchange);
+    if (responseExchange !== profileExchange) {
+      findings.push({
+        checkCode: "exchange_variants_primary_exchange",
+        fieldName: "exchange_short_name",
+        severity: "warning",
+        message:
+          "The base exchange in FMP exchange variants disagrees with the current profile exchange.",
+        evidence: { responseExchange, profileExchange },
+        sourceReference: "profile-exchange-mismatch",
+      });
+    }
+  }
+
+  const missingExistingActiveVariants = context.existingVariants
+    .filter((variant) => variant.is_actively_trading === true)
+    .map((variant) =>
+      variantKey(variant.symbol_variant, variant.exchange_short_name)
+    )
+    .filter(
+      (key): key is string => key !== null && !incomingKeys.has(key),
+    )
+    .sort();
+  if (missingExistingActiveVariants.length > 0) {
+    findings.push({
+      checkCode: "exchange_variant_set_regression",
+      fieldName: "symbol_variant",
+      severity: "warning",
+      message:
+        "FMP omitted one or more previously known active exchange variants.",
+      evidence: { missingExistingActiveVariants },
+      sourceReference: "missing-previously-active-variants",
+    });
+  }
+
+  return findings;
+}
+
+export async function syncExchangeVariantQualityFindings(
+  supabase: SupabaseClient,
+  job: QueueJob,
+  findings: DataQualityFinding[],
+  responseSizeBytes: number,
+): Promise<void> {
+  const endpointUrl = `${FMP_ENDPOINT_URL}?symbol=${
+    encodeURIComponent(job.symbol)
+  }`;
+  const enrichedFindings = findings.map((finding) => ({
+    ...finding,
+    evidence: {
+      ...finding.evidence,
+      responseSizeBytes,
+      endpointUrl,
+      queueJobId: job.id,
+      retryCount: job.retry_count,
+      maxRetries: job.max_retries,
+    },
+  }));
+  const persisted = await syncDataQualityFindings(
+    supabase,
+    { symbol: job.symbol, provider: "fmp", endpoint: "exchange-variants" },
+    enrichedFindings,
+  );
+  if (!persisted) {
+    throw new Error(
+      `Failed to synchronize exchange-variant quality findings for ${job.symbol}`,
+    );
+  }
 }

--- a/supabase/functions/lib/fetch-fmp-exchange-variants.ts
+++ b/supabase/functions/lib/fetch-fmp-exchange-variants.ts
@@ -11,8 +11,8 @@ import type {
   SupabaseExchangeVariantRecord,
 } from '../fetch-fmp-exchange-variants/types.ts';
 import {
-  recordEmptyExchangeVariantsResponse,
-  resolveEmptyExchangeVariantsResponse,
+  syncExchangeVariantQualityFindings,
+  validateExchangeVariantsResponse,
 } from './exchange-variants-quality.ts';
 
 const FMP_API_KEY = Deno.env.get('FMP_API_KEY');
@@ -30,6 +30,8 @@ export async function fetchExchangeVariantsLogic(
       error: `Configuration Error: fetchExchangeVariantsLogic was called for job type ${job.data_type}. Expected 'exchange-variants'.`,
     };
   }
+
+  let actualSizeBytes = 0;
 
   try {
     if (!FMP_API_KEY) {
@@ -61,7 +63,7 @@ export async function fetchExchangeVariantsLogic(
 
     // CRITICAL: Get the ACTUAL data transfer size (what FMP bills for)
     const contentLength = response.headers.get('Content-Length');
-    let actualSizeBytes = contentLength ? parseInt(contentLength, 10) : 0;
+    actualSizeBytes = contentLength ? parseInt(contentLength, 10) : 0;
     if (actualSizeBytes === 0) {
       console.warn(`[fetchExchangeVariantsLogic] Content-Length header missing for ${job.symbol}. Using fallback estimate.`);
       actualSizeBytes = 80000; // 80 KB conservative estimate
@@ -73,143 +75,64 @@ export async function fetchExchangeVariantsLogic(
       throw new Error(`FMP API returned invalid response format for ${job.symbol}. Expected array, got: ${typeof fmpVariantsResult}`);
     }
 
+    let qualityFindings: ReturnType<typeof validateExchangeVariantsResponse>;
+
     if (fmpVariantsResult.length === 0) {
-      // An empty array is not valid exchange coverage for a listed symbol.
-      // Persist the upstream anomaly before creating the profile-derived
-      // sentinel, so the rendering fallback cannot mask the quality issue.
-      await recordEmptyExchangeVariantsResponse(
+      qualityFindings = validateExchangeVariantsResponse({
+        symbol: job.symbol,
+        response: fmpVariantsResult,
+        profileExchange: null,
+        profileExists: true,
+        knownExchanges: [],
+        existingVariants: [],
+      });
+    } else {
+      const [profileResult, existingResult, exchangesResult] = await Promise.all([
+        supabase
+          .from('profiles')
+          .select('exchange')
+          .eq('symbol', job.symbol)
+          .maybeSingle(),
+        supabase
+          .from('exchange_variants')
+          .select('symbol_variant, exchange_short_name, is_actively_trading')
+          .eq('symbol', job.symbol),
+        supabase.from('available_exchanges').select('exchange'),
+      ]);
+
+      if (profileResult.error && profileResult.error.code !== 'PGRST116') {
+        throw new Error(`Profile lookup failed: ${profileResult.error.message}`);
+      }
+      if (existingResult.error) {
+        throw new Error(`Existing variant lookup failed: ${existingResult.error.message}`);
+      }
+      if (exchangesResult.error) {
+        throw new Error(`Exchange registry lookup failed: ${exchangesResult.error.message}`);
+      }
+
+      qualityFindings = validateExchangeVariantsResponse({
+        symbol: job.symbol,
+        response: fmpVariantsResult,
+        profileExchange: profileResult.data?.exchange ?? null,
+        profileExists: profileResult.data != null,
+        knownExchanges: (exchangesResult.data ?? []).map((row) => row.exchange),
+        existingVariants: existingResult.data ?? [],
+      });
+    }
+
+    if (qualityFindings.length > 0) {
+      await syncExchangeVariantQualityFindings(
         supabase,
         job,
+        qualityFindings,
         actualSizeBytes,
       );
-
-      // CRITICAL: Create a sentinel record for exchange-variants if FMP returns empty array
-      // This prevents infinite retries for symbols that genuinely have no exchange variants
-      // CRITICAL: The sentinel record uses the actual symbol as symbol_variant (not a sentinel value)
-      // This allows the card to visualize it as "the only variant" (the base symbol itself)
-      // CRITICAL: Populate sentinel record with data from profiles table so it can render correctly
-
-      // Fetch profile data to populate the sentinel record
-      const { data: profileData, error: profileError } = await supabase
-        .from('profiles')
-        .select('price, beta, average_volume, market_cap, last_dividend, range, change, currency, cik, isin, cusip, exchange, image, ipo_date, default_image, is_actively_trading')
-        .eq('symbol', job.symbol)
-        .maybeSingle();
-
-      if (profileError && profileError.code !== 'PGRST116') {
-        console.warn(`[fetchExchangeVariantsLogic] Error fetching profile data for sentinel record: ${profileError.message}`);
-      }
-
-      // Derive exchange_short_name from profile data
-      // The exchange field in profiles is usually the short name (e.g., "NYSE", "NASDAQ")
-      // Use it directly, or 'N/A' if not available
-      const exchangeShortName = profileData?.exchange ?? 'N/A';
-
-      const sentinelRecord: SupabaseExchangeVariantRecord = {
-        symbol: job.symbol,
-        symbol_variant: job.symbol, // CRITICAL: Use actual symbol, not sentinel value - this makes it visualizable
-        exchange_short_name: exchangeShortName, // Use exchange from profile, or 'N/A' if not available
-        fetched_at: new Date().toISOString(),
-        // Populate from profile data if available
-        price: profileData?.price ?? null,
-        beta: profileData?.beta ?? null,
-        vol_avg: profileData?.average_volume ?? null, // Map average_volume to vol_avg
-        mkt_cap: profileData?.market_cap ?? null,
-        last_div: profileData?.last_dividend ?? null,
-        range: profileData?.range ?? null,
-        changes: profileData?.change ?? null, // Map change to changes
-        currency: profileData?.currency ?? null,
-        cik: profileData?.cik ?? null,
-        isin: profileData?.isin ?? null,
-        cusip: profileData?.cusip ?? null,
-        exchange: profileData?.exchange ?? null,
-        dcf_diff: null, // Not available in profiles
-        dcf: null, // Not available in profiles
-        image: profileData?.image ?? null,
-        ipo_date: profileData?.ipo_date ?? null,
-        default_image: profileData?.default_image ?? null,
-        is_actively_trading: profileData?.is_actively_trading ?? true, // Use profile value, default to true
-      } as SupabaseExchangeVariantRecord; // Type assertion for fetched_at
-
-      // Check if sentinel record already exists
-      // CRITICAL: Check for both old format (exchange_short_name = 'N/A') and new format (exchange_short_name = actual exchange)
-      // This handles migration from old sentinel records to new populated ones
-      const { data: existingSentinel, error: checkError } = await supabase
-        .from('exchange_variants')
-        .select('symbol_variant, exchange_short_name')
-        .eq('symbol', job.symbol)
-        .eq('symbol_variant', job.symbol)
-        .in('exchange_short_name', [exchangeShortName, 'N/A']) // Check both old and new format
-        .maybeSingle();
-
-      if (checkError && checkError.code !== 'PGRST116') {
-        console.warn(`[fetchExchangeVariantsLogic] Error checking for sentinel record: ${checkError.message}`);
-      }
-
-      if (!existingSentinel) {
-        // Insert sentinel record
-        const { error: upsertError } = await supabase
-          .from('exchange_variants')
-          .upsert(sentinelRecord, {
-            onConflict: 'symbol_variant,exchange_short_name',
-            count: 'exact',
-          });
-
-        if (upsertError) {
-          throw new Error(`Database upsert of sentinel record failed: ${upsertError.message}`);
-        }
-        console.log(`[fetchExchangeVariantsLogic] Created sentinel exchange-variants record for ${job.symbol} (treating as the only variant).`);
-      } else {
-        // Update existing sentinel record with latest profile data
-        // This ensures the sentinel record stays in sync with profile updates
-        const updateData: Partial<SupabaseExchangeVariantRecord> = {
-          fetched_at: new Date().toISOString(),
-        };
-
-        // Update fields from profile if available
-        if (profileData) {
-          updateData.price = profileData.price ?? null;
-          updateData.beta = profileData.beta ?? null;
-          updateData.vol_avg = profileData.average_volume ?? null;
-          updateData.mkt_cap = profileData.market_cap ?? null;
-          updateData.last_div = profileData.last_dividend ?? null;
-          updateData.range = profileData.range ?? null;
-          updateData.changes = profileData.change ?? null;
-          updateData.currency = profileData.currency ?? null;
-          updateData.cik = profileData.cik ?? null;
-          updateData.isin = profileData.isin ?? null;
-          updateData.cusip = profileData.cusip ?? null;
-          updateData.exchange = profileData.exchange ?? null;
-          updateData.image = profileData.image ?? null;
-          updateData.ipo_date = profileData.ipo_date ?? null;
-          updateData.default_image = profileData.default_image ?? null;
-          updateData.is_actively_trading = profileData.is_actively_trading ?? true;
-
-          // Update exchange_short_name if exchange changed
-          if (profileData.exchange) {
-            updateData.exchange_short_name = profileData.exchange;
-          }
-        }
-
-        // CRITICAL: Update using the existing sentinel's exchange_short_name (could be 'N/A' or actual exchange)
-        // This allows migration from old format to new format
-        const { error: updateError } = await supabase
-          .from('exchange_variants')
-          .update(updateData)
-          .eq('symbol', job.symbol)
-          .eq('symbol_variant', job.symbol)
-          .in('exchange_short_name', [exchangeShortName, 'N/A']); // Update both old and new format
-
-        if (updateError) {
-          console.warn(`[fetchExchangeVariantsLogic] Failed to update sentinel record: ${updateError.message}`);
-        } else {
-          console.log(`[fetchExchangeVariantsLogic] Updated sentinel exchange-variants record for ${job.symbol} with profile data.`);
-        }
-      }
-
       return {
-        success: true,
-        dataSizeBytes: actualSizeBytes, // Still count the API call size
+        success: false,
+        dataSizeBytes: actualSizeBytes,
+        error: `Exchange-variant response failed data-quality checks for ${job.symbol}: ${[
+          ...new Set(qualityFindings.map((finding) => finding.checkCode)),
+        ].join(', ')}. Stored data was preserved.`,
       };
     }
 
@@ -222,19 +145,9 @@ export async function fetchExchangeVariantsLogic(
 
     // CRITICAL: Map FMP data to Supabase record format
     // NOTE: job.symbol is the symbol (e.g., "AAPL"), and FMP returns variant symbols (e.g., "AAPL.DE")
-    const recordsToUpsert: SupabaseExchangeVariantRecord[] = (
+    const recordsToReplace: SupabaseExchangeVariantRecord[] = (
       fmpVariantsResult as FmpExchangeVariantData[]
     )
-      .filter((fmpEntry) => {
-        const isValid = fmpEntry.symbol && fmpEntry.exchangeShortName;
-        if (!isValid) {
-          console.warn(
-            `[fetchExchangeVariantsLogic] Skipping invalid FMP exchange variant record for ${job.symbol} due to missing symbol or exchangeShortName:`,
-            fmpEntry
-          );
-        }
-        return isValid;
-      })
       .map((fmpEntry) => ({
         symbol: job.symbol, // CRITICAL: Use job.symbol as symbol (renamed from base_symbol)
         symbol_variant: fmpEntry.symbol, // Renamed from variant_symbol
@@ -260,23 +173,20 @@ export async function fetchExchangeVariantsLogic(
         fetched_at: new Date().toISOString(), // CRITICAL: Update fetched_at on upsert to prevent infinite job creation
       }));
 
-    if (recordsToUpsert.length > 0) {
-      const { error: upsertError } = await supabase
-        .from('exchange_variants')
-        .upsert(recordsToUpsert, {
-          onConflict: 'symbol_variant,exchange_short_name',
-          count: 'exact',
-        });
-
-      if (upsertError) {
-        throw new Error(`Database upsert failed: ${upsertError.message}`);
-      }
-
+    const { error: replaceError } = await supabase.rpc(
+      'replace_exchange_variants_v2',
+      { p_symbol: job.symbol, p_records: recordsToReplace },
+    );
+    if (replaceError) {
+      throw new Error(`Atomic exchange-variant replacement failed: ${replaceError.message}`);
     }
 
-    // A successfully persisted non-empty response clears only the matching
-    // empty-response anomaly. Other exchange-variant findings remain open.
-    await resolveEmptyExchangeVariantsResponse(supabase, job.symbol);
+    await syncExchangeVariantQualityFindings(
+      supabase,
+      job,
+      [],
+      actualSizeBytes,
+    );
 
     return {
       success: true,
@@ -285,7 +195,7 @@ export async function fetchExchangeVariantsLogic(
   } catch (error) {
     return {
       success: false,
-      dataSizeBytes: 0,
+      dataSizeBytes: actualSizeBytes,
       error: error instanceof Error ? error.message : 'Unknown error',
     };
   }

--- a/supabase/migrations/20260801000000_gate_exchange_variant_quality.sql
+++ b/supabase/migrations/20260801000000_gate_exchange_variant_quality.sql
@@ -1,0 +1,135 @@
+-- Replace one symbol's validated exchange variants as a single transaction.
+-- The Edge Function performs provider-quality checks before calling this RPC;
+-- these defensive checks ensure malformed payloads cannot partially replace
+-- the last-known-good set.
+
+CREATE OR REPLACE FUNCTION public.replace_exchange_variants_v2(
+  p_symbol text,
+  p_records jsonb
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_symbol text := pg_catalog.upper(pg_catalog.btrim(p_symbol));
+  v_inserted integer := 0;
+BEGIN
+  IF v_symbol IS NULL OR v_symbol = '' THEN
+    RAISE EXCEPTION 'p_symbol must not be empty';
+  END IF;
+  IF p_records IS NULL
+     OR pg_catalog.jsonb_typeof(p_records) <> 'array'
+     OR pg_catalog.jsonb_array_length(p_records) = 0
+  THEN
+    RAISE EXCEPTION 'p_records must be a non-empty JSON array';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.jsonb_array_elements(p_records) AS item
+    WHERE pg_catalog.jsonb_typeof(item) <> 'object'
+  ) THEN
+    RAISE EXCEPTION 'every exchange-variant record must be a JSON object';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.jsonb_populate_recordset(
+      NULL::public.exchange_variants,
+      p_records
+    ) AS record
+    WHERE record.symbol IS NULL
+       OR pg_catalog.upper(pg_catalog.btrim(record.symbol)) <> v_symbol
+       OR NULLIF(pg_catalog.btrim(record.symbol_variant), '') IS NULL
+       OR NULLIF(pg_catalog.btrim(record.exchange_short_name), '') IS NULL
+  ) THEN
+    RAISE EXCEPTION
+      'records must match p_symbol and contain symbol_variant and exchange_short_name';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.jsonb_populate_recordset(
+      NULL::public.exchange_variants,
+      p_records
+    ) AS record
+    GROUP BY
+      pg_catalog.upper(pg_catalog.btrim(record.symbol_variant)),
+      pg_catalog.upper(pg_catalog.btrim(record.exchange_short_name))
+    HAVING pg_catalog.count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'p_records contains duplicate exchange variants';
+  END IF;
+
+  DELETE FROM public.exchange_variants
+  WHERE symbol = v_symbol;
+
+  INSERT INTO public.exchange_variants (
+    symbol,
+    symbol_variant,
+    exchange_short_name,
+    price,
+    beta,
+    vol_avg,
+    mkt_cap,
+    last_div,
+    range,
+    changes,
+    currency,
+    cik,
+    isin,
+    cusip,
+    exchange,
+    dcf_diff,
+    dcf,
+    image,
+    ipo_date,
+    default_image,
+    is_actively_trading,
+    fetched_at
+  )
+  SELECT
+    v_symbol,
+    pg_catalog.upper(pg_catalog.btrim(record.symbol_variant)),
+    pg_catalog.upper(pg_catalog.btrim(record.exchange_short_name)),
+    record.price,
+    record.beta,
+    record.vol_avg,
+    record.mkt_cap,
+    record.last_div,
+    record.range,
+    record.changes,
+    record.currency,
+    record.cik,
+    record.isin,
+    record.cusip,
+    record.exchange,
+    record.dcf_diff,
+    record.dcf,
+    record.image,
+    record.ipo_date,
+    record.default_image,
+    record.is_actively_trading,
+    COALESCE(record.fetched_at, pg_catalog.now())
+  FROM pg_catalog.jsonb_populate_recordset(
+    NULL::public.exchange_variants,
+    p_records
+  ) AS record;
+
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  RETURN v_inserted;
+END;
+$$;
+
+ALTER FUNCTION public.replace_exchange_variants_v2(text, jsonb)
+OWNER TO postgres;
+
+REVOKE ALL
+ON FUNCTION public.replace_exchange_variants_v2(text, jsonb)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE
+ON FUNCTION public.replace_exchange_variants_v2(text, jsonb)
+TO service_role;
+
+COMMENT ON FUNCTION public.replace_exchange_variants_v2(text, jsonb) IS
+  'Atomically replaces a symbol exchange-variant set after Edge Function quality validation; rejects empty, mismatched, and duplicate payloads.';


### PR DESCRIPTION
```Rejects empty, malformed, duplicate, inconsistent, or regressed exchange-variant responses and records them in data_quality_issues. Validated sets replace stored variants atomically, preserving last-known-good data whenever validation or persistence fails. Includes security, rollback, and automated test coverage.
```