### PR TITLE
Model overlapping exchange variant sets

### DIFF
--- a/scripts/security/verify-exchange-variant-quality-gate.sql
+++ b/scripts/security/verify-exchange-variant-quality-gate.sql
@@ -1,7 +1,9 @@
 BEGIN;
 
 INSERT INTO public.profiles (symbol, exchange, is_actively_trading)
-VALUES ('QAVX', 'NASDAQ', true)
+VALUES
+  ('QAVX', 'NASDAQ', true),
+  ('QAVY', 'NASDAQ', true)
 ON CONFLICT (symbol) DO NOTHING;
 
 INSERT INTO public.exchange_variants (
@@ -13,7 +15,7 @@ INSERT INTO public.exchange_variants (
 VALUES
   ('QAVX', 'QAVX', 'NASDAQ', true),
   ('QAVX', 'QAVX.DE', 'XETRA', true)
-ON CONFLICT (symbol_variant, exchange_short_name) DO UPDATE
+ON CONFLICT (symbol, symbol_variant, exchange_short_name) DO UPDATE
 SET symbol = EXCLUDED.symbol;
 
 DO $$
@@ -43,6 +45,31 @@ BEGIN
      )
   THEN
     RAISE EXCEPTION 'validated replacement did not remove the obsolete row';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  PERFORM public.replace_exchange_variants_v2(
+    'QAVY',
+    '[{
+      "symbol": "QAVY",
+      "symbol_variant": "QAVX",
+      "exchange_short_name": "NASDAQ",
+      "price": 10,
+      "is_actively_trading": true
+    }]'::jsonb
+  );
+
+  IF (
+    SELECT count(*)
+    FROM public.exchange_variants
+    WHERE symbol_variant = 'QAVX'
+      AND exchange_short_name = 'NASDAQ'
+  ) <> 2 THEN
+    RAISE EXCEPTION
+      'overlapping variant was not retained for both base symbols';
   END IF;
 END;
 $$;

--- a/supabase/functions/__tests__/exchange-variants-data-quality.test.ts
+++ b/supabase/functions/__tests__/exchange-variants-data-quality.test.ts
@@ -66,11 +66,6 @@ function mockClient(options: {
     exchange_short_name: string;
     is_actively_trading: boolean | null;
   }>;
-  owners?: Array<{
-    symbol: string;
-    symbol_variant: string;
-    exchange_short_name: string;
-  }>;
   exchanges?: string[];
   profile?: { exchange: string } | null;
   syncError?: string;
@@ -103,8 +98,6 @@ function mockClient(options: {
           select: () => chain,
           eq: () =>
             Promise.resolve({ data: options.existing ?? [], error: null }),
-          in: () =>
-            Promise.resolve({ data: options.owners ?? [], error: null }),
         };
         return chain;
       }
@@ -169,37 +162,6 @@ Deno.test(
       assertExists(
         (findings[0].evidence as Record<string, unknown>).endpointUrl,
       );
-    });
-  },
-);
-
-Deno.test(
-  "cross-symbol ownership conflict is recorded before atomic replacement",
-  async () => {
-    await withFmpResponse([baseVariant], async () => {
-      const { supabase, rpcCalls } = mockClient({
-        profile: { exchange: "NASDAQ" },
-        exchanges: ["NASDAQ"],
-        owners: [{
-          symbol: "OTHER",
-          symbol_variant: "TEST",
-          exchange_short_name: "NASDAQ",
-        }],
-      });
-      const result = await fetchExchangeVariantsLogic(job, supabase);
-
-      assertEquals(result.success, false);
-      assertEquals(rpcCalls.map((call) => call.name), [
-        "sync_data_quality_issues",
-      ]);
-      const findings = rpcCalls[0].args.p_findings as Array<
-        Record<string, unknown>
-      >;
-      assertEquals(
-        findings[0].check_code,
-        "exchange_variant_ownership_conflict",
-      );
-      assertEquals(findings[0].severity, "critical");
     });
   },
 );
@@ -280,6 +242,32 @@ Deno.test(
 );
 
 Deno.test(
+  "same variant on a corrected exchange replaces stale classification",
+  async () => {
+    await withFmpResponse([baseVariant], async () => {
+      const { supabase, rpcCalls } = mockClient({
+        profile: { exchange: "NASDAQ" },
+        exchanges: ["NASDAQ", "NYSE"],
+        existing: [
+          {
+            symbol_variant: "TEST",
+            exchange_short_name: "NYSE",
+            is_actively_trading: true,
+          },
+        ],
+      });
+      const result = await fetchExchangeVariantsLogic(job, supabase);
+
+      assertEquals(result, { success: true, dataSizeBytes: 100 });
+      assertEquals(rpcCalls.map((call) => call.name), [
+        "replace_exchange_variants_v2",
+        "sync_data_quality_issues",
+      ]);
+    });
+  },
+);
+
+Deno.test(
   "quality failure never replaces data when issue persistence fails",
   async () => {
     await withFmpResponse([baseVariant], async () => {
@@ -318,7 +306,6 @@ Deno.test("validator rejects incomplete and unknown exchange data", () => {
     profileExists: true,
     knownExchanges: ["NASDAQ"],
     existingVariants: [],
-    variantOwners: [],
   });
 
   assertEquals(
@@ -335,7 +322,6 @@ Deno.test("validator flags duplicate records and a base-exchange mismatch", () =
     profileExists: true,
     knownExchanges: ["NASDAQ", "NYSE", "XETRA"],
     existingVariants: [],
-    variantOwners: [],
   });
 
   assertEquals(

--- a/supabase/functions/fetch-fmp-exchange-variants/index.ts
+++ b/supabase/functions/fetch-fmp-exchange-variants/index.ts
@@ -117,7 +117,7 @@ async function fetchAndProcessSymbolExchangeVariants(
       const { error: upsertError, count } = await supabaseAdmin
         .from("exchange_variants")
         .upsert(recordsToUpsert, {
-          onConflict: "symbol_variant,exchange_short_name",
+          onConflict: "symbol,symbol_variant,exchange_short_name",
           count: "exact",
         });
 

--- a/supabase/functions/lib/exchange-variants-quality.ts
+++ b/supabase/functions/lib/exchange-variants-quality.ts
@@ -12,12 +12,6 @@ interface ExistingExchangeVariant {
   is_actively_trading: boolean | null;
 }
 
-interface OwnedExchangeVariant {
-  symbol: string;
-  symbol_variant: string;
-  exchange_short_name: string;
-}
-
 interface ExchangeVariantQualityContext {
   symbol: string;
   response: unknown[];
@@ -25,7 +19,6 @@ interface ExchangeVariantQualityContext {
   profileExists: boolean;
   knownExchanges: string[];
   existingVariants: ExistingExchangeVariant[];
-  variantOwners: OwnedExchangeVariant[];
 }
 
 function normalized(value: unknown): string | null {
@@ -109,34 +102,6 @@ export function validateExchangeVariantsResponse(
       message: "FMP returned duplicate exchange-variant records.",
       evidence: { duplicateKeys: [...duplicateKeys].sort() },
       sourceReference: "duplicate-records",
-    });
-  }
-
-  const ownershipConflicts = context.variantOwners
-    .map((variant) => ({
-      key: variantKey(
-        variant.symbol_variant,
-        variant.exchange_short_name,
-      ),
-      existingOwner: normalized(variant.symbol),
-    }))
-    .filter(
-      (conflict): conflict is { key: string; existingOwner: string } =>
-        conflict.key !== null &&
-        conflict.existingOwner !== null &&
-        conflict.existingOwner !== baseSymbol &&
-        incomingKeys.has(conflict.key),
-    )
-    .sort((left, right) => left.key.localeCompare(right.key));
-  if (ownershipConflicts.length > 0) {
-    findings.push({
-      checkCode: "exchange_variant_ownership_conflict",
-      fieldName: "symbol_variant",
-      severity: "critical",
-      message:
-        "FMP returned exchange variants already assigned to a different base symbol.",
-      evidence: { ownershipConflicts },
-      sourceReference: "cross-symbol-ownership-conflict",
     });
   }
 
@@ -225,14 +190,28 @@ export function validateExchangeVariantsResponse(
     }
   }
 
+  const incomingVariantSymbols = new Set(
+    responseEntries
+      .map((entry) => normalized(entry.symbol))
+      .filter((symbol): symbol is string => symbol !== null),
+  );
   const missingExistingActiveVariants = context.existingVariants
     .filter((variant) => variant.is_actively_trading === true)
-    .map((variant) =>
-      variantKey(variant.symbol_variant, variant.exchange_short_name)
-    )
+    .map((variant) => ({
+      key: variantKey(
+        variant.symbol_variant,
+        variant.exchange_short_name,
+      ),
+      symbol: normalized(variant.symbol_variant),
+    }))
     .filter(
-      (key): key is string => key !== null && !incomingKeys.has(key),
+      (variant): variant is { key: string; symbol: string } =>
+        variant.key !== null &&
+        variant.symbol !== null &&
+        !incomingKeys.has(variant.key) &&
+        !incomingVariantSymbols.has(variant.symbol),
     )
+    .map((variant) => variant.key)
     .sort();
   if (missingExistingActiveVariants.length > 0) {
     findings.push({

--- a/supabase/functions/lib/fetch-fmp-exchange-variants.ts
+++ b/supabase/functions/lib/fetch-fmp-exchange-variants.ts
@@ -86,33 +86,9 @@ export async function fetchExchangeVariantsLogic(
         profileExists: true,
         knownExchanges: [],
         existingVariants: [],
-        variantOwners: [],
       });
     } else {
-      const incomingVariantSymbols = [...new Set(
-        fmpVariantsResult
-          .map((entry) =>
-            entry && typeof entry === 'object' && !Array.isArray(entry)
-              ? (entry as Record<string, unknown>).symbol
-              : null
-          )
-          .filter((symbol): symbol is string =>
-            typeof symbol === 'string' && symbol.trim().length > 0
-          )
-          .map((symbol) => symbol.trim().toUpperCase()),
-      )];
-      const ownershipPromise = incomingVariantSymbols.length === 0
-        ? Promise.resolve({ data: [], error: null })
-        : supabase
-          .from('exchange_variants')
-          .select('symbol, symbol_variant, exchange_short_name')
-          .in('symbol_variant', incomingVariantSymbols);
-      const [
-        profileResult,
-        existingResult,
-        exchangesResult,
-        ownershipResult,
-      ] = await Promise.all([
+      const [profileResult, existingResult, exchangesResult] = await Promise.all([
         supabase
           .from('profiles')
           .select('exchange')
@@ -123,7 +99,6 @@ export async function fetchExchangeVariantsLogic(
           .select('symbol_variant, exchange_short_name, is_actively_trading')
           .eq('symbol', job.symbol),
         supabase.from('available_exchanges').select('exchange'),
-        ownershipPromise,
       ]);
 
       if (profileResult.error && profileResult.error.code !== 'PGRST116') {
@@ -135,10 +110,6 @@ export async function fetchExchangeVariantsLogic(
       if (exchangesResult.error) {
         throw new Error(`Exchange registry lookup failed: ${exchangesResult.error.message}`);
       }
-      if (ownershipResult.error) {
-        throw new Error(`Variant ownership lookup failed: ${ownershipResult.error.message}`);
-      }
-
       qualityFindings = validateExchangeVariantsResponse({
         symbol: job.symbol,
         response: fmpVariantsResult,
@@ -146,7 +117,6 @@ export async function fetchExchangeVariantsLogic(
         profileExists: profileResult.data != null,
         knownExchanges: (exchangesResult.data ?? []).map((row) => row.exchange),
         existingVariants: existingResult.data ?? [],
-        variantOwners: ownershipResult.data ?? [],
       });
     }
 

--- a/supabase/migrations/20260801020000_model_overlapping_exchange_variant_sets.sql
+++ b/supabase/migrations/20260801020000_model_overlapping_exchange_variant_sets.sql
@@ -1,0 +1,51 @@
+-- FMP exchange-variant searches return overlapping security families. The
+-- same variant can therefore belong to the result sets of multiple requested
+-- base symbols. Model that many-to-many relationship instead of assigning a
+-- variant globally to whichever base symbol was refreshed first.
+
+DO $$
+DECLARE
+  v_constraint_name text;
+  v_primary_key_columns text[];
+BEGIN
+  SELECT
+    constraint_row.conname,
+    pg_catalog.array_agg(attribute_row.attname ORDER BY key_row.ordinality)
+  INTO v_constraint_name, v_primary_key_columns
+  FROM pg_catalog.pg_constraint AS constraint_row
+  CROSS JOIN LATERAL pg_catalog.unnest(constraint_row.conkey)
+    WITH ORDINALITY AS key_row(attnum, ordinality)
+  JOIN pg_catalog.pg_attribute AS attribute_row
+    ON attribute_row.attrelid = constraint_row.conrelid
+   AND attribute_row.attnum = key_row.attnum
+  WHERE constraint_row.conrelid = 'public.exchange_variants'::regclass
+    AND constraint_row.contype = 'p'
+  GROUP BY constraint_row.conname;
+
+  IF v_primary_key_columns IS DISTINCT FROM ARRAY[
+    'symbol',
+    'symbol_variant',
+    'exchange_short_name'
+  ]::text[] THEN
+    IF v_constraint_name IS NOT NULL THEN
+      EXECUTE pg_catalog.format(
+        'ALTER TABLE public.exchange_variants DROP CONSTRAINT %I',
+        v_constraint_name
+      );
+    END IF;
+
+    ALTER TABLE public.exchange_variants
+      ADD CONSTRAINT exchange_variants_pkey
+      PRIMARY KEY (symbol, symbol_variant, exchange_short_name);
+  END IF;
+END;
+$$;
+
+COMMENT ON TABLE public.exchange_variants IS
+  'Stores each base symbol exchange-variant result set from FMP; related base symbols may contain overlapping variants.';
+
+COMMENT ON COLUMN public.exchange_variants.symbol IS
+  'Requested base symbol whose FMP result set contains this variant; part of the composite primary key.';
+
+COMMENT ON COLUMN public.exchange_variants.symbol_variant IS
+  'Exchange-specific variant returned for the requested base symbol; part of the composite primary key.';


### PR DESCRIPTION
Models FMP exchange variants as overlapping result sets by including the requested base symbol in the primary key. Also treats a ticker moving between exchange codes as a valid correction rather than a missing-variant regression. Atomic replacement and last-known-good protections remain intact.