### PR TITLE
Schedule daily exchange variant refreshes

### DIFF
--- a/scripts/security/verify-scheduled-exchange-variant-policy.sql
+++ b/scripts/security/verify-scheduled-exchange-variant-policy.sql
@@ -1,0 +1,29 @@
+DO $$
+DECLARE
+  v_strategy text;
+  v_ttl_minutes integer;
+  v_estimated_bytes bigint;
+BEGIN
+  SELECT
+    refresh_strategy,
+    default_ttl_minutes,
+    estimated_data_size_bytes
+  INTO v_strategy, v_ttl_minutes, v_estimated_bytes
+  FROM public.data_type_registry_v2
+  WHERE data_type = 'exchange-variants';
+
+  IF v_strategy <> 'scheduled' THEN
+    RAISE EXCEPTION
+      'exchange variants must be scheduled, found %', v_strategy;
+  END IF;
+  IF v_ttl_minutes <> 1440 THEN
+    RAISE EXCEPTION
+      'exchange variant TTL must be 1440 minutes, found %', v_ttl_minutes;
+  END IF;
+  IF v_estimated_bytes <> 20000 THEN
+    RAISE EXCEPTION
+      'exchange variant estimate must be 20000 bytes, found %',
+      v_estimated_bytes;
+  END IF;
+END;
+$$;

--- a/supabase/functions/__tests__/exchange-variants-data-quality.test.ts
+++ b/supabase/functions/__tests__/exchange-variants-data-quality.test.ts
@@ -120,6 +120,7 @@ function mockClient(options: {
 async function withFmpResponse(
   payload: unknown,
   callback: () => Promise<void>,
+  includeContentLength = true,
 ) {
   const originalFetch = globalThis.fetch;
   try {
@@ -127,7 +128,7 @@ async function withFmpResponse(
       Promise.resolve(
         new Response(JSON.stringify(payload), {
           status: 200,
-          headers: { "Content-Length": "100" },
+          headers: includeContentLength ? { "Content-Length": "100" } : {},
         }),
       );
     await callback();
@@ -163,6 +164,26 @@ Deno.test(
         (findings[0].evidence as Record<string, unknown>).endpointUrl,
       );
     });
+  },
+);
+
+Deno.test(
+  "missing content length records measured response bytes",
+  async () => {
+    const payload = [baseVariant];
+    await withFmpResponse(payload, async () => {
+      const { supabase } = mockClient({
+        profile: { exchange: "NASDAQ" },
+        exchanges: ["NASDAQ"],
+      });
+      const result = await fetchExchangeVariantsLogic(job, supabase);
+
+      assertEquals(result, {
+        success: true,
+        dataSizeBytes: new TextEncoder().encode(JSON.stringify(payload))
+          .byteLength,
+      });
+    }, false);
   },
 );
 

--- a/supabase/functions/lib/fetch-fmp-exchange-variants.ts
+++ b/supabase/functions/lib/fetch-fmp-exchange-variants.ts
@@ -62,15 +62,26 @@ export async function fetchExchangeVariantsLogic(
       throw new Error(`FMP API error: ${response.status} ${errorText}`);
     }
 
-    // CRITICAL: Get the ACTUAL data transfer size (what FMP bills for)
+    const responseBody = new Uint8Array(await response.arrayBuffer());
+
+    // Prefer FMP's reported transfer size. When it omits Content-Length,
+    // measure the body we actually received instead of booking an arbitrary
+    // 80 KB fallback for a response that is usually only a few kilobytes.
     const contentLength = response.headers.get('Content-Length');
-    actualSizeBytes = contentLength ? parseInt(contentLength, 10) : 0;
-    if (actualSizeBytes === 0) {
-      console.warn(`[fetchExchangeVariantsLogic] Content-Length header missing for ${job.symbol}. Using fallback estimate.`);
-      actualSizeBytes = 80000; // 80 KB conservative estimate
+    const reportedSizeBytes = contentLength ? parseInt(contentLength, 10) : 0;
+    if (Number.isFinite(reportedSizeBytes) && reportedSizeBytes > 0) {
+      actualSizeBytes = reportedSizeBytes;
+    } else {
+      actualSizeBytes = responseBody.byteLength;
+      console.warn(`[fetchExchangeVariantsLogic] Content-Length header missing or invalid for ${job.symbol}. Measured ${actualSizeBytes} response bytes.`);
     }
 
-    const fmpVariantsResult: unknown = await response.json();
+    let fmpVariantsResult: unknown;
+    try {
+      fmpVariantsResult = JSON.parse(new TextDecoder().decode(responseBody));
+    } catch {
+      throw new Error(`FMP API returned invalid JSON for ${job.symbol}`);
+    }
 
     if (!Array.isArray(fmpVariantsResult)) {
       throw new Error(`FMP API returned invalid response format for ${job.symbol}. Expected array, got: ${typeof fmpVariantsResult}`);

--- a/supabase/migrations/20260801030000_schedule_exchange_variant_refreshes.sql
+++ b/supabase/migrations/20260801030000_schedule_exchange_variant_refreshes.sql
@@ -1,0 +1,22 @@
+-- Exchange variants are durable filter/card data and have now passed the
+-- quality-gated refresh calibration. Include them in the bounded scheduled
+-- round robin with their existing daily TTL.
+
+DO $$
+BEGIN
+  UPDATE public.data_type_registry_v2
+  SET refresh_strategy = 'scheduled',
+      default_ttl_minutes = 1440,
+      estimated_data_size_bytes = 20000,
+      updated_at = pg_catalog.now()
+  WHERE data_type = 'exchange-variants';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION
+      'exchange-variants registry row is required before scheduling';
+  END IF;
+END;
+$$;
+
+COMMENT ON COLUMN public.data_type_registry_v2.estimated_data_size_bytes IS
+  'Conservative pre-fetch estimate used for queue planning; workers record the measured response size after each call.';


### PR DESCRIPTION
Adds exchange variants to the daily scheduled refresh cycle. When FMP omits `Content-Length`, the processor now measures the actual response body instead of recording an inaccurate 80 KB fallback.