### PR TITLE
Cool down deterministic quality failures

### DIFF
--- a/scripts/security/verify-data-quality-failure-terminalization.sql
+++ b/scripts/security/verify-data-quality-failure-terminalization.sql
@@ -6,6 +6,8 @@ DECLARE
   v_retryable_job uuid := gen_random_uuid();
   v_status text;
   v_retry_count integer;
+  v_retry_after timestamptz;
+  v_last_failure_at timestamptz;
 BEGIN
   INSERT INTO public.api_call_queue_v2 (
     id,
@@ -53,6 +55,18 @@ BEGIN
       v_status,
       v_retry_count;
   END IF;
+  SELECT cooldown.retry_after, cooldown.last_failure_at
+  INTO v_retry_after, v_last_failure_at
+  FROM public.refresh_failure_cooldowns_v2 AS cooldown
+  WHERE cooldown.symbol = 'QAVT'
+    AND cooldown.data_type = 'exchange-variants';
+
+  IF v_retry_after IS NULL
+     OR v_retry_after - v_last_failure_at < interval '24 hours'
+  THEN
+    RAISE EXCEPTION
+      'deterministic data-quality failure did not receive a 24-hour cooldown';
+  END IF;
   IF NOT EXISTS (
     SELECT 1
     FROM public.api_data_usage_v2
@@ -80,6 +94,14 @@ BEGIN
       'ordinary failure did not retain normal retry behavior: status %, retry %',
       v_status,
       v_retry_count;
+  END IF;
+
+  IF public.refresh_failure_retry_interval_v2(
+       'temporary database error',
+       1
+     ) <> interval '1 hour'
+  THEN
+    RAISE EXCEPTION 'ordinary failure backoff changed unexpectedly';
   END IF;
 END;
 $$;

--- a/supabase/migrations/20260801040000_cool_down_deterministic_quality_failures.sql
+++ b/supabase/migrations/20260801040000_cool_down_deterministic_quality_failures.sql
@@ -1,0 +1,52 @@
+-- A deterministic provider-quality failure will not improve when the same
+-- scheduled request is repeated an hour later. Keep the issue open and the
+-- last-known-good data intact, but wait one full refresh TTL before probing
+-- the provider again. Demand-driven work can still bypass this cooldown.
+
+CREATE OR REPLACE FUNCTION public.refresh_failure_retry_interval_v2(
+  p_error_message text,
+  p_consecutive_failures integer
+)
+RETURNS interval
+LANGUAGE sql
+IMMUTABLE
+SET search_path = ''
+AS $$
+  SELECT CASE
+    WHEN p_error_message LIKE 'Non-retryable data-quality failure:%'
+      THEN interval '24 hours'
+    WHEN p_error_message ILIKE '%stale%'
+         AND p_error_message ILIKE '%timestamp%'
+      THEN interval '24 hours'
+    ELSE pg_catalog.make_interval(
+      hours => LEAST(
+        24,
+        pg_catalog.power(
+          2,
+          LEAST(GREATEST(p_consecutive_failures, 1) - 1, 5)
+        )::integer
+      )
+    )
+  END;
+$$;
+
+ALTER FUNCTION public.refresh_failure_retry_interval_v2(text, integer)
+OWNER TO postgres;
+
+REVOKE ALL
+ON FUNCTION public.refresh_failure_retry_interval_v2(text, integer)
+FROM PUBLIC, anon, authenticated, service_role;
+
+-- Extend cooldowns already created by the current rollout. This prevents the
+-- scheduler from repeating those billed calls before the next daily probe.
+UPDATE public.refresh_failure_cooldowns_v2 AS cooldown
+SET
+  retry_after = cooldown.last_failure_at + interval '24 hours',
+  updated_at = pg_catalog.now()
+WHERE cooldown.last_error_message
+        LIKE 'Non-retryable data-quality failure:%'
+  AND cooldown.retry_after
+        < cooldown.last_failure_at + interval '24 hours';
+
+COMMENT ON FUNCTION public.refresh_failure_retry_interval_v2(text, integer) IS
+  'Returns a 24-hour cooldown for deterministic data-quality and timestamp-regression failures; other failures retain capped exponential backoff.';


### PR DESCRIPTION
Changed deterministic QA failures to retry once daily instead of hourly. Existing data remains preserved and ordinary temporary failures retain faster retries.