### PR TITLE
Verify Compass ranking behavior and performance

### DIFF
--- a/docs/verification/RANKING_VERIFICATION_2026-08-02.md
+++ b/docs/verification/RANKING_VERIFICATION_2026-08-02.md
@@ -1,0 +1,116 @@
+# Compass Ranking Verification — 2026-08-02
+
+## Outcome
+
+The current Compass ranking function passed deterministic score, eligibility,
+filter, and missing-data checks on both a clean PostgreSQL 17 database and a
+fresh allowlisted production-like snapshot. The snapshot benchmark also
+establishes a new query-plan and server-side latency baseline.
+
+- PostgreSQL: 17.6
+- Supabase CLI used by the project: 2.111.0
+- FMP requests made: 0
+- Clean-database ranking verification: PASS
+- Production-like snapshot ranking verification: PASS
+- Synthetic and snapshot benchmarks: COMPLETE
+
+The snapshot export contained only `profiles`, `listed_symbols`,
+`exchange_variants`, and `compass_pillar_scores`. Cron, Edge Runtime, and
+callable Vault secrets were disabled or absent throughout local execution.
+
+## Manual score calculations
+
+The fixture validates the exact metric-to-weight mapping rather than trusting
+the leaderboard output as its own oracle.
+
+| Symbol | Calculation | Expected | Actual |
+| --- | --- | ---: | ---: |
+| `VFY_ALPHA` | Eight normalized metrics at 80, each weighted 0.125 | 80.00 | 80.00 |
+| `VFY_GAMMA` | Four metrics at 100 and four at 0, each weighted 0.125 | 50.00 | 50.00 |
+| `VFY_WEIGHTED` | `10×.05 + 20×.10 + 30×.15 + 40×.20 + 50×.10 + 60×.15 + 70×.10 + 80×.15` | 48.00 | 48.00 |
+
+The expected order was `VFY_ALPHA`, `VFY_GAMMA`, `VFY_WEIGHTED`, then
+`VFY_NULL`; it matched exactly on the clean and populated databases.
+
+## Filters, eligibility, and missing data
+
+The following contracts passed:
+
+- industry-only, exchange-only, and combined filters;
+- case-insensitive exchange values;
+- `NULL` and empty filter arrays both mean no filter;
+- nonmatching filters return no rows;
+- curated inactive symbols are excluded;
+- symbols confirmed inactive by the FMP universe snapshot are excluded;
+- eligible symbols without a score row are excluded;
+- a row with one missing normalized metric receives a null composite score and
+  sorts after complete scores.
+
+The fresh snapshot contained:
+
+| Measure | Rows |
+| --- | ---: |
+| Profiles | 17,980 |
+| Listed symbols | 17,983 |
+| Curated active symbols | 5,271 |
+| Leaderboard-eligible after FMP status | 5,168 |
+| FMP-confirmed inactive among curated active | 103 |
+| Exchange variants | 23,745 |
+| Scored symbols | 5,271 |
+| Incomplete normalized score rows | 0 |
+| Orphan score / variant rows | 0 / 0 |
+| Auth users / queued jobs in snapshot database | 0 / 0 |
+
+## Query plan and latency baseline
+
+All timings are server-side warm-cache measurements on the same local host.
+They are regression baselines, not public API SLOs.
+
+### Production-like snapshot
+
+The filtered case used the two largest industries (`Biotechnology` and
+`Banks - Regional`) and exchanges (`NASDAQ` and `NYSE`). One hundred samples of each
+shape were alternated after warm-up.
+
+| Query | Samples | p50 | p95 | Maximum | Recorded plan time |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Unfiltered | 100 | 4.546 ms | 5.834 ms | 11.498 ms | 4.586 ms |
+| Top-two industries and exchanges | 100 | 15.207 ms | 19.568 ms | 26.155 ms | 15.050 ms |
+
+The unfiltered nested plan uses sequential scans of the 5,271 score rows and
+17,983 listing rows, a hash join producing 5,168 eligible rows, and a 45 KB
+top-N heapsort for the best 50.
+
+The filtered nested plan scans the eligible listing set, probes the score
+primary key, and uses an index-only exchange-variant lookup for matching
+industries. It produced 912 candidates before a 42 KB top-N sort. PostgreSQL
+estimated only 7 candidates, so filtered cardinality estimation is the main
+plan characteristic to watch as the universe grows; current latency remains
+well within the recorded baseline.
+
+### Synthetic 18,000-symbol stress fixture
+
+| Query | Rows returned | Execution time | Shared-buffer hits |
+| --- | ---: | ---: | ---: |
+| Unfiltered | 50 | 18.711 ms | 989 |
+| Two industries and two exchanges | 50 | 36.574 ms | 75,815 |
+
+For comparable future local runs, investigate if snapshot p95 exceeds roughly
+twice this baseline (12 ms unfiltered or 39 ms filtered), or if the filtered
+plan stops using indexed symbol/exchange lookups. These are regression review
+triggers, not user-facing latency guarantees.
+
+## Reproducible checks
+
+- `supabase/tests/backend_ranking_verification.sql` contains the transactional
+  manual calculations and behavior checks.
+- `supabase/tests/backend_ranking_benchmark.sql` contains the rolled-back
+  18,000-symbol stress benchmark.
+- `supabase/tests/backend_ranking_snapshot_benchmark.sql` contains the guarded
+  100-sample production-like benchmark.
+- `scripts/export-ranking-snapshot.sh` creates the four-table data-only export,
+  rejects protected schemas, and records `fmp_requests=0` in its manifest.
+
+Do not run these fixture files against a linked or production database. They
+are intended only for an isolated local database with outbound execution paths
+disabled.

--- a/supabase/tests/backend_ranking_snapshot_benchmark.sql
+++ b/supabase/tests/backend_ranking_snapshot_benchmark.sql
@@ -40,6 +40,18 @@ SELECT
   (SELECT COUNT(*) FROM public.profiles) AS profiles,
   (SELECT COUNT(*) FROM public.listed_symbols) AS listed_symbols,
   (SELECT COUNT(*) FROM public.listed_symbols WHERE is_active) AS active_symbols,
+  (
+    SELECT COUNT(*)
+    FROM public.listed_symbols
+    WHERE is_active
+      AND fmp_is_actively_trading IS DISTINCT FROM false
+  ) AS leaderboard_eligible_symbols,
+  (
+    SELECT COUNT(*)
+    FROM public.listed_symbols
+    WHERE is_active
+      AND fmp_is_actively_trading = false
+  ) AS fmp_inactive_symbols,
   (SELECT COUNT(*) FROM public.exchange_variants) AS exchange_variants,
   (SELECT COUNT(*) FROM public.compass_pillar_scores) AS scored_symbols,
   (
@@ -114,7 +126,7 @@ BEGIN
     benchmark_weights, selected_industries, selected_exchanges
   );
 
-  FOR sample_number IN 1..30 LOOP
+  FOR sample_number IN 1..100 LOOP
     started_at := clock_timestamp();
     PERFORM *
     FROM public.get_weighted_leaderboard(benchmark_weights, NULL, NULL);
@@ -138,7 +150,7 @@ BEGIN
 END;
 $$;
 
-\echo 'SNAPSHOT: 30-sample latency summary (server-side milliseconds)'
+\echo 'SNAPSHOT: 100-sample latency summary (server-side milliseconds)'
 SELECT
   variant,
   COUNT(*) AS samples,

--- a/supabase/tests/backend_ranking_verification.sql
+++ b/supabase/tests/backend_ranking_verification.sql
@@ -35,14 +35,24 @@ VALUES
   ('VFY_ALPHA', 'Verification Alpha'),
   ('VFY_BETA', 'Verification Beta'),
   ('VFY_GAMMA', 'Verification Gamma'),
-  ('VFY_NULL', 'Verification Missing Data');
+  ('VFY_NULL', 'Verification Missing Metric'),
+  ('VFY_WEIGHTED', 'Verification Weighted Score'),
+  ('VFY_FMP_OFF', 'Verification FMP Inactive'),
+  ('VFY_NO_SCORE', 'Verification Missing Score Row');
 
-INSERT INTO public.listed_symbols (symbol, is_active)
+INSERT INTO public.listed_symbols (
+  symbol,
+  is_active,
+  fmp_is_actively_trading
+)
 VALUES
-  ('VFY_ALPHA', TRUE),
-  ('VFY_BETA', FALSE),
-  ('VFY_GAMMA', TRUE),
-  ('VFY_NULL', TRUE);
+  ('VFY_ALPHA', TRUE, TRUE),
+  ('VFY_BETA', FALSE, TRUE),
+  ('VFY_GAMMA', TRUE, TRUE),
+  ('VFY_NULL', TRUE, TRUE),
+  ('VFY_WEIGHTED', TRUE, TRUE),
+  ('VFY_FMP_OFF', TRUE, FALSE),
+  ('VFY_NO_SCORE', TRUE, TRUE);
 
 INSERT INTO public.compass_pillar_scores (
   symbol, industry, market_cap, revenue_ttm,
@@ -57,31 +67,44 @@ VALUES
   ('VFY_ALPHA', 'VFY Technology', 1000, 500, 80, 1, 80, 1, 80, 1, 80, 1, 80, 1, 80, 1, 80, 1, 80, 1),
   ('VFY_BETA', 'VFY Technology', 900, 450, 60, 2, 60, 2, 60, 2, 60, 2, 60, 2, 60, 2, 60, 2, 60, 2),
   ('VFY_GAMMA', 'VFY Healthcare', 800, 400, 100, 3, 0, 3, 100, 3, 0, 3, 100, 3, 0, 3, 100, 3, 0, 3),
-  ('VFY_NULL', 'VFY Technology', 700, NULL, NULL, 4, 40, 4, 40, 4, 40, 4, 40, 4, 40, 4, 40, 4, 40, 4);
+  ('VFY_NULL', 'VFY Technology', 700, NULL, NULL, 4, 40, 4, 40, 4, 40, 4, 40, 4, 40, 4, 40, 4, 40, 4),
+  ('VFY_WEIGHTED', 'VFY Industrials', 600, 300, 10, 5, 20, 5, 30, 5, 50, 5, 60, 5, 40, 5, 70, 5, 80, 5),
+  ('VFY_FMP_OFF', 'VFY Technology', 500, 250, 100, 6, 100, 6, 100, 6, 100, 6, 100, 6, 100, 6, 100, 6, 100, 6);
 
 INSERT INTO public.exchange_variants (
   symbol, symbol_variant, exchange_short_name
 )
 VALUES
-  ('VFY_ALPHA', 'VFY_ALPHA', 'NASDAQ'),
-  ('VFY_BETA', 'VFY_BETA', 'NYSE'),
-  ('VFY_GAMMA', 'VFY_GAMMA', 'NASDAQ'),
-  ('VFY_NULL', 'VFY_NULL', 'NASDAQ');
+  ('VFY_ALPHA', 'VFY_ALPHA', 'VFY-XNAS'),
+  ('VFY_BETA', 'VFY_BETA', 'VFY-XNYS'),
+  ('VFY_GAMMA', 'VFY_GAMMA', 'VFY-XNAS'),
+  ('VFY_NULL', 'VFY_NULL', 'VFY-XNAS'),
+  ('VFY_WEIGHTED', 'VFY_WEIGHTED', 'VFY-XNYS'),
+  ('VFY_FMP_OFF', 'VFY_FMP_OFF', 'VFY-XNAS'),
+  ('VFY_NO_SCORE', 'VFY_NO_SCORE', 'VFY-XNAS');
 
 DO $$
 DECLARE
   equal_weights CONSTANT jsonb :=
     '{"revenue":0.125,"value":0.125,"sentiment":0.125,"growth":0.125,"profitability":0.125,"buyback":0.125,"income":0.125,"health":0.125}'::jsonb;
+  custom_weights CONSTANT jsonb :=
+    '{"revenue":0.05,"value":0.10,"sentiment":0.15,"growth":0.20,"profitability":0.10,"buyback":0.15,"income":0.10,"health":0.15}'::jsonb;
   actual_symbols text[];
   expected_symbols text[];
   actual_score numeric;
+  actual_count integer;
 BEGIN
   SELECT array_agg(symbol ORDER BY rank)
   INTO actual_symbols
-  FROM public.get_weighted_leaderboard(equal_weights, ARRAY['VFY Technology', 'VFY Healthcare'], NULL)
+  FROM public.get_weighted_leaderboard(
+    equal_weights,
+    ARRAY['VFY Technology', 'VFY Healthcare', 'VFY Industrials'],
+    NULL
+  )
   WHERE symbol LIKE 'VFY\_%' ESCAPE '\';
 
-  IF actual_symbols IS DISTINCT FROM ARRAY['VFY_ALPHA', 'VFY_GAMMA', 'VFY_NULL']::text[] THEN
+  IF actual_symbols IS DISTINCT FROM
+     ARRAY['VFY_ALPHA', 'VFY_GAMMA', 'VFY_WEIGHTED', 'VFY_NULL']::text[] THEN
     RAISE EXCEPTION 'Ranking/active/missing-data order mismatch: %', actual_symbols;
   END IF;
 
@@ -103,9 +126,36 @@ BEGIN
     RAISE EXCEPTION 'Manual score mismatch for VFY_GAMMA: expected 50.00, got %', actual_score;
   END IF;
 
+  SELECT composite_score
+  INTO actual_score
+  FROM public.get_weighted_leaderboard(custom_weights, ARRAY['VFY Industrials'], NULL)
+  WHERE symbol = 'VFY_WEIGHTED';
+
+  IF actual_score IS DISTINCT FROM 48.00::numeric THEN
+    RAISE EXCEPTION 'Manual score mismatch for VFY_WEIGHTED: expected 48.00, got %', actual_score;
+  END IF;
+
   SELECT array_agg(symbol ORDER BY rank)
   INTO actual_symbols
-  FROM public.get_weighted_leaderboard(equal_weights, ARRAY['VFY Technology'], ARRAY['nasdaq'])
+  FROM public.get_weighted_leaderboard(equal_weights, ARRAY['VFY Technology'], NULL)
+  WHERE symbol LIKE 'VFY\_%' ESCAPE '\';
+
+  IF actual_symbols IS DISTINCT FROM ARRAY['VFY_ALPHA', 'VFY_NULL']::text[] THEN
+    RAISE EXCEPTION 'Industry-only filter or eligibility mismatch: %', actual_symbols;
+  END IF;
+
+  SELECT array_agg(symbol ORDER BY rank)
+  INTO actual_symbols
+  FROM public.get_weighted_leaderboard(equal_weights, NULL, ARRAY['vfy-xnas'])
+  WHERE symbol LIKE 'VFY\_%' ESCAPE '\';
+
+  IF actual_symbols IS DISTINCT FROM ARRAY['VFY_ALPHA', 'VFY_GAMMA', 'VFY_NULL']::text[] THEN
+    RAISE EXCEPTION 'Exchange-only filter or case-folding mismatch: %', actual_symbols;
+  END IF;
+
+  SELECT array_agg(symbol ORDER BY rank)
+  INTO actual_symbols
+  FROM public.get_weighted_leaderboard(equal_weights, ARRAY['VFY Technology'], ARRAY['vfy-xnas'])
   WHERE symbol LIKE 'VFY\_%' ESCAPE '\';
 
   IF actual_symbols IS DISTINCT FROM ARRAY['VFY_ALPHA', 'VFY_NULL']::text[] THEN
@@ -123,6 +173,40 @@ BEGIN
   IF actual_symbols IS DISTINCT FROM expected_symbols THEN
     RAISE EXCEPTION 'Empty filters should behave as no filters: empty=%, null=%',
       actual_symbols, expected_symbols;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO actual_count
+  FROM public.get_weighted_leaderboard(
+    equal_weights,
+    ARRAY['VFY Does Not Exist'],
+    ARRAY['VFY-NONE']
+  );
+
+  IF actual_count <> 0 THEN
+    RAISE EXCEPTION 'Nonmatching filters should return zero rows, got %', actual_count;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.get_weighted_leaderboard(
+      equal_weights,
+      ARRAY['VFY Technology', 'VFY Healthcare', 'VFY Industrials'],
+      NULL
+    )
+    WHERE symbol IN ('VFY_BETA', 'VFY_FMP_OFF', 'VFY_NO_SCORE')
+  ) THEN
+    RAISE EXCEPTION
+      'Inactive, FMP-inactive, or absent-score symbols leaked into the leaderboard';
+  END IF;
+
+  SELECT composite_score
+  INTO actual_score
+  FROM public.get_weighted_leaderboard(equal_weights, ARRAY['VFY Technology'], NULL)
+  WHERE symbol = 'VFY_NULL';
+
+  IF actual_score IS NOT NULL THEN
+    RAISE EXCEPTION 'Missing normalized metric should yield a NULL composite score';
   END IF;
 END;
 $$;
@@ -254,11 +338,20 @@ BEGIN
   END IF;
 
   IF (SELECT COUNT(*) FROM cron.job WHERE jobname = 'check-stale-data-v2') <> 1
-     OR (SELECT COUNT(*) FROM cron.job WHERE jobname = 'queue-scheduled-refreshes-v2') <> 1
      OR (SELECT COUNT(*) FROM cron.job WHERE jobname = 'invoke-processor-v2') <> 1
      OR (SELECT COUNT(*) FROM cron.job WHERE jobname = 'maintain-queue-partitions-v2') <> 1
      OR (SELECT COUNT(*) FROM cron.job WHERE jobname = 'refresh-compass-leaderboard-mv') <> 1 THEN
     RAISE EXCEPTION 'One or more required scheduler jobs are missing or non-unique';
+  END IF;
+
+  -- Clean installs intentionally leave scheduled queueing absent until the
+  -- guarded production activation step. If activated, it must still be unique.
+  IF (
+    SELECT COUNT(*)
+    FROM cron.job
+    WHERE jobname = 'queue-scheduled-refreshes-v2'
+  ) > 1 THEN
+    RAISE EXCEPTION 'Scheduled refresh queue job is duplicated';
   END IF;
 
   IF POSITION(


### PR DESCRIPTION
Expands Compass verification with independent manual score calculations and explicit coverage for industry/exchange filters, FMP eligibility, inactive symbols, missing score rows, and null metrics.
Updates the production-like benchmark to 100 samples and records current query plans, eligibility counts, and latency baselines.
Validation:

- Clean and production-like ranking verification passed
- 100/100 database contract assertions passed
- Database lint passed
- 8/8 Playwright tests passed
- Production build passed
- Zero FMP requests