### PR TITLE
Add Compass quality shadow audit

### DIFF
--- a/docs/verification/COMPASS_FINANCIAL_MODEL_AUDIT_2026-08-02.md
+++ b/docs/verification/COMPASS_FINANCIAL_MODEL_AUDIT_2026-08-02.md
@@ -1,0 +1,116 @@
+# Compass Financial Model Audit — 2026-08-02
+
+## Outcome
+
+The current Compass implementation calculates and filters its scores correctly,
+but a correct calculation is not yet a reliable high-quality value strategy.
+The live top results contain value traps, illiquid microcaps, severe shareholder
+dilution, and financial securities whose accounting is not comparable with an
+ordinary operating company.
+
+No FMP requests were made for this audit. No production score or ranking was
+changed.
+
+## What the current labels actually measure
+
+| Compass label | Current production input |
+| --- | --- |
+| Revenue | Revenue divided by market capitalization (inverse P/S) |
+| Value | Enterprise-value multiple |
+| Sentiment | Six-month net insider transaction dollars |
+| Growth | PEG ratio |
+| Profitability | Lower of earnings yield and free-cash-flow yield |
+| Buyback | Five-year average share-count change |
+| Income | Dividend yield |
+| Health | Net-debt/cash-flow tier plus quick ratio |
+
+Several labels therefore imply more than their inputs establish. In particular,
+the Profitability pillar measures cheapness of earnings and cash flow, not the
+quality or durability of those profits.
+
+## Live failure examples
+
+The read-only audit found these among the current leaders:
+
+- `RDGT` ranked second for Value despite a roughly $0.7 million market cap,
+  declining revenue, approximately 284% year-over-year dilution, and only one
+  positive free-cash-flow year out of five.
+- `CISS` ranked seventh for Value despite effectively no usable market-cap value
+  and approximately 2,127% year-over-year dilution.
+- A preferred-style Prudential security appeared in the Quality leaders, even
+  though it is not comparable with a common operating company.
+- Banks, insurers, and credit vehicles occupied much of the Quality top 20
+  because industrial-company cash-flow and leverage measures do not mean the
+  same thing for financial companies.
+
+These are model-quality findings, not investment recommendations about the
+named securities.
+
+## Model direction
+
+Compass v2 should select quality first and cheapness second:
+
+1. Establish that the row represents a current, analyzable common stock with
+   adequate source coverage and practical tradability.
+2. Use separate models for operating companies, financial companies, and real
+   estate companies.
+3. Reject mathematically invalid valuation inputs. Negative or zero P/E, PEG,
+   price-to-FCF, and enterprise multiples must not receive a favorable rank.
+4. Measure quality over several years: cash-flow consistency, gross profit on
+   assets, accrual quality, revenue durability, balance-sheet safety, and share
+   dilution.
+5. Rank value within comparable sectors and industries after the quality floor
+   is met.
+6. Scale insider activity by company size rather than comparing raw dollars.
+7. Report data coverage and risk reasons with every shadow score. Missing data
+   must not silently become a neutral or favorable result.
+
+This direction follows established evidence that profitability improves value
+selection and that quality combines profitability, growth, safety, and capital
+returned to shareholders:
+
+- Robert Novy-Marx, [The Other Side of Value](https://www.nber.org/papers/w15940)
+- Asness, Frazzini, and Pedersen, [Quality Minus Junk](https://www.aqr.com/-/media/AQR/Documents/Insights/Working-Papers/Quality-Minus-Junk.pdf)
+- Joseph Piotroski, [Value Investing: The Use of Historical Financial Statement Information](https://ideas.repec.org/a/bla/joares/v38y2000ip1-41.html)
+
+The liquidity controls also reflect the SEC's warning that microcap securities
+can have limited public information, low trading volume, and greater
+manipulation risk: [Microcap Stock: A Guide for Investors](https://www.sec.gov/about/reports-publications/investorpubsmicrocapstock).
+
+## First implementation slice
+
+Migration `20260802000000_add_compass_quality_shadow_audit.sql` adds a
+service-only, read-only audit of the existing top 50. It reports the current
+rank beside provisional gate failures and risk flags. It does not alter the
+leaderboard.
+
+The provisional gate currently tests:
+
+- fund/ETF and security-name leakage;
+- whether a specialized financial or real-estate model is required;
+- market cap below $50 million;
+- average daily dollar volume below $500,000;
+- fewer than three annual statements;
+- fewer than three positive free-cash-flow years for operating companies;
+- missing or stale financial inputs;
+- more than 50% year-over-year share dilution.
+
+The audit also warns about less severe liquidity, dilution, accrual, debt,
+revenue, and invalid-ratio risks. These thresholds are hypotheses to measure,
+not final production policy.
+
+## Validation sequence
+
+1. Run the shadow audit against each current investor profile.
+2. Measure how many top-50 candidates fail each rule and manually inspect the
+   borderline cases.
+3. Agree on production cutoffs from that evidence.
+4. Build the operating-company v2 score alongside the existing score.
+5. Validate calculations by hand and compare old/new top 50 results.
+6. Use point-in-time filings, prices, and delistings for historical testing so
+   future information and survivorship cannot leak into results.
+7. Switch user recommendations only after the shadow results are credible and
+   explainable.
+
+This sequence consumes no FMP quota until a separate historical-data plan is
+explicitly approved.

--- a/docs/verification/RANKING_VERIFICATION_2026-08-02.md
+++ b/docs/verification/RANKING_VERIFICATION_2026-08-02.md
@@ -7,6 +7,11 @@ filter, and missing-data checks on both a clean PostgreSQL 17 database and a
 fresh allowlisted production-like snapshot. The snapshot benchmark also
 establishes a new query-plan and server-side latency baseline.
 
+This verifies implementation correctness, not investment-model quality. The
+separate [financial model audit](./COMPASS_FINANCIAL_MODEL_AUDIT_2026-08-02.md)
+documents value-trap and comparability failures found in the live leaders and
+the shadow-validation path for Compass v2.
+
 - PostgreSQL: 17.6
 - Supabase CLI used by the project: 2.111.0
 - FMP requests made: 0

--- a/supabase/migrations/20260802000000_add_compass_quality_shadow_audit.sql
+++ b/supabase/migrations/20260802000000_add_compass_quality_shadow_audit.sql
@@ -1,0 +1,408 @@
+-- Add a service-only shadow audit for the current Compass leaderboard.
+--
+-- This does not change ranking or eligibility. The provisional gates expose
+-- cheap-looking candidates that need to be removed or scored by a specialized
+-- model before Compass v2 can safely replace the existing recommendations.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_compass_quality_shadow_audit(
+  p_weights jsonb,
+  p_limit integer DEFAULT 50,
+  p_industries text[] DEFAULT NULL,
+  p_exchanges text[] DEFAULT NULL
+)
+RETURNS TABLE(
+  current_rank bigint,
+  symbol text,
+  current_score numeric,
+  company_name text,
+  sector text,
+  industry text,
+  exchange text,
+  market_cap bigint,
+  average_daily_dollar_volume numeric,
+  annual_statement_years integer,
+  positive_fcf_years integer,
+  latest_annual_date date,
+  latest_accepted_at timestamptz,
+  revenue_growth_yoy numeric,
+  share_dilution_yoy numeric,
+  gross_profit_to_assets numeric,
+  accrual_ratio numeric,
+  free_cash_flow_margin numeric,
+  price_to_earnings numeric,
+  peg numeric,
+  price_to_free_cash_flow numeric,
+  enterprise_multiple numeric,
+  model_class text,
+  passes_provisional_gate boolean,
+  gate_failures text[],
+  risk_flags text[]
+)
+LANGUAGE sql
+STABLE
+SET search_path = ''
+AS $$
+  WITH current_leaders AS (
+    SELECT leaderboard.*
+    FROM public.get_weighted_leaderboard(
+      p_weights,
+      p_industries,
+      p_exchanges
+    ) AS leaderboard
+    ORDER BY leaderboard.rank
+    LIMIT greatest(
+      1,
+      least(coalesce(p_limit, 50), 50)
+    )
+  ),
+  annual_rows AS (
+    SELECT
+      statements.symbol,
+      statements.date,
+      statements.accepted_date,
+      pg_catalog.row_number() OVER (
+        PARTITION BY statements.symbol
+        ORDER BY statements.date DESC, statements.accepted_date DESC NULLS LAST
+      ) AS recency,
+      CASE
+        WHEN pg_catalog.jsonb_typeof(
+          statements.income_statement_payload -> 'revenue'
+        ) = 'number'
+          THEN (statements.income_statement_payload ->> 'revenue')::numeric
+      END AS revenue,
+      CASE
+        WHEN pg_catalog.jsonb_typeof(
+          statements.income_statement_payload -> 'grossProfit'
+        ) = 'number'
+          THEN (statements.income_statement_payload ->> 'grossProfit')::numeric
+      END AS gross_profit,
+      CASE
+        WHEN pg_catalog.jsonb_typeof(
+          statements.income_statement_payload -> 'netIncome'
+        ) = 'number'
+          THEN (statements.income_statement_payload ->> 'netIncome')::numeric
+      END AS net_income,
+      CASE
+        WHEN pg_catalog.jsonb_typeof(
+          statements.income_statement_payload -> 'weightedAverageShsOutDil'
+        ) = 'number'
+          THEN (
+            statements.income_statement_payload ->> 'weightedAverageShsOutDil'
+          )::numeric
+        WHEN pg_catalog.jsonb_typeof(
+          statements.income_statement_payload -> 'weightedAverageShsOut'
+        ) = 'number'
+          THEN (
+            statements.income_statement_payload ->> 'weightedAverageShsOut'
+          )::numeric
+      END AS diluted_shares,
+      CASE
+        WHEN pg_catalog.jsonb_typeof(
+          statements.balance_sheet_payload -> 'totalAssets'
+        ) = 'number'
+          THEN (statements.balance_sheet_payload ->> 'totalAssets')::numeric
+      END AS total_assets,
+      CASE
+        WHEN pg_catalog.jsonb_typeof(
+          statements.balance_sheet_payload -> 'totalDebt'
+        ) = 'number'
+          THEN (statements.balance_sheet_payload ->> 'totalDebt')::numeric
+      END AS total_debt,
+      CASE
+        WHEN pg_catalog.jsonb_typeof(
+          statements.cash_flow_payload -> 'operatingCashFlow'
+        ) = 'number'
+          THEN (
+            statements.cash_flow_payload ->> 'operatingCashFlow'
+          )::numeric
+        WHEN pg_catalog.jsonb_typeof(
+          statements.cash_flow_payload -> 'netCashProvidedByOperatingActivities'
+        ) = 'number'
+          THEN (
+            statements.cash_flow_payload
+              ->> 'netCashProvidedByOperatingActivities'
+          )::numeric
+      END AS operating_cash_flow,
+      CASE
+        WHEN pg_catalog.jsonb_typeof(
+          statements.cash_flow_payload -> 'freeCashFlow'
+        ) = 'number'
+          THEN (statements.cash_flow_payload ->> 'freeCashFlow')::numeric
+      END AS free_cash_flow
+    FROM public.financial_statements AS statements
+    INNER JOIN current_leaders AS leaders
+      ON leaders.symbol = statements.symbol
+    WHERE statements.period = 'FY'
+  ),
+  annual_summary AS (
+    SELECT
+      annual.symbol,
+      pg_catalog.count(*) FILTER (WHERE annual.recency <= 5)::integer
+        AS annual_statement_years,
+      pg_catalog.count(*) FILTER (
+        WHERE annual.recency <= 5 AND annual.free_cash_flow > 0
+      )::integer AS positive_fcf_years,
+      pg_catalog.max(annual.date) FILTER (WHERE annual.recency = 1)
+        AS latest_annual_date,
+      pg_catalog.max(annual.accepted_date) FILTER (WHERE annual.recency = 1)
+        AS latest_accepted_at,
+      pg_catalog.max(annual.revenue) FILTER (WHERE annual.recency = 1)
+        AS latest_revenue,
+      pg_catalog.max(annual.revenue) FILTER (WHERE annual.recency = 2)
+        AS previous_revenue,
+      pg_catalog.max(annual.diluted_shares) FILTER (WHERE annual.recency = 1)
+        AS latest_diluted_shares,
+      pg_catalog.max(annual.diluted_shares) FILTER (WHERE annual.recency = 2)
+        AS previous_diluted_shares,
+      pg_catalog.max(annual.gross_profit) FILTER (WHERE annual.recency = 1)
+        AS latest_gross_profit,
+      pg_catalog.max(annual.net_income) FILTER (WHERE annual.recency = 1)
+        AS latest_net_income,
+      pg_catalog.max(annual.total_assets) FILTER (WHERE annual.recency = 1)
+        AS latest_total_assets,
+      pg_catalog.max(annual.operating_cash_flow) FILTER (WHERE annual.recency = 1)
+        AS latest_operating_cash_flow,
+      pg_catalog.max(annual.free_cash_flow) FILTER (WHERE annual.recency = 1)
+        AS latest_free_cash_flow,
+      pg_catalog.max(annual.total_debt) FILTER (WHERE annual.recency = 1)
+        AS latest_total_debt,
+      pg_catalog.max(annual.total_debt) FILTER (WHERE annual.recency = 2)
+        AS previous_total_debt
+    FROM annual_rows AS annual
+    WHERE annual.recency <= 5
+    GROUP BY annual.symbol
+  ),
+  raw_diagnostics AS (
+    SELECT
+      leaders.rank AS current_rank,
+      leaders.symbol,
+      leaders.composite_score AS current_score,
+      profile.company_name,
+      profile.sector,
+      leaders.industry,
+      profile.exchange,
+      profile.market_cap,
+      CASE
+        WHEN profile.price > 0 AND profile.average_volume > 0
+          THEN profile.price::numeric * profile.average_volume::numeric
+      END AS average_daily_dollar_volume,
+      coalesce(annual.annual_statement_years, 0)
+        AS annual_statement_years,
+      coalesce(annual.positive_fcf_years, 0)
+        AS positive_fcf_years,
+      annual.latest_annual_date,
+      annual.latest_accepted_at,
+      (annual.latest_revenue - annual.previous_revenue)
+        / nullif(pg_catalog.abs(annual.previous_revenue), 0)
+        AS revenue_growth_yoy,
+      (annual.latest_diluted_shares - annual.previous_diluted_shares)
+        / nullif(annual.previous_diluted_shares, 0)
+        AS share_dilution_yoy,
+      annual.latest_gross_profit
+        / nullif(pg_catalog.abs(annual.latest_total_assets), 0)
+        AS gross_profit_to_assets,
+      (annual.latest_net_income - annual.latest_operating_cash_flow)
+        / nullif(pg_catalog.abs(annual.latest_total_assets), 0)
+        AS accrual_ratio,
+      annual.latest_free_cash_flow
+        / nullif(pg_catalog.abs(annual.latest_revenue), 0)
+        AS free_cash_flow_margin,
+      ratios.price_to_earnings_ratio_ttm::numeric AS price_to_earnings,
+      ratios.price_to_earnings_growth_ratio_ttm::numeric AS peg,
+      ratios.price_to_free_cash_flow_ratio_ttm::numeric
+        AS price_to_free_cash_flow,
+      ratios.enterprise_value_multiple_ttm::numeric AS enterprise_multiple,
+      profile.is_etf,
+      profile.is_fund,
+      profile.is_adr,
+      profile.price,
+      profile.modified_at AS profile_updated_at,
+      ratios.updated_at AS ratios_updated_at,
+      CASE
+        WHEN profile.sector ILIKE '%financial%'
+          OR profile.industry ~* '(bank|insurance|credit services|asset management|mortgage)'
+          THEN 'financial'
+        WHEN profile.sector ILIKE '%real estate%'
+          OR profile.industry ~* '(reit|real estate)'
+          THEN 'real-estate'
+        ELSE 'operating'
+      END AS model_class,
+      CASE
+        WHEN profile.company_name ~* '(preferred (stock|shares?)|depositary shares?|warrants?|rights?|units?|notes? due|bonds?|debentures?)'
+          OR profile.company_name ~ '[[:space:]][0-9]+([.][0-9]+)?%?$'
+          THEN true
+        ELSE false
+      END AS security_name_requires_review,
+      CASE
+        WHEN annual.previous_total_debt IS NOT NULL
+          THEN (annual.latest_total_debt - annual.previous_total_debt)
+            / nullif(pg_catalog.abs(annual.previous_total_debt), 0)
+      END AS debt_growth_yoy
+    FROM current_leaders AS leaders
+    LEFT JOIN public.profiles AS profile
+      ON profile.symbol = leaders.symbol
+    LEFT JOIN public.ratios_ttm AS ratios
+      ON ratios.symbol = leaders.symbol
+    LEFT JOIN annual_summary AS annual
+      ON annual.symbol = leaders.symbol
+  ),
+  evaluated AS (
+    SELECT
+      diagnostics.*,
+      pg_catalog.array_remove(ARRAY[
+        CASE
+          WHEN diagnostics.is_etf IS TRUE OR diagnostics.is_fund IS TRUE
+            THEN 'fund_or_etf'
+        END,
+        CASE
+          WHEN diagnostics.security_name_requires_review
+            THEN 'security_type_requires_review'
+        END,
+        CASE
+          WHEN diagnostics.model_class <> 'operating'
+            THEN 'specialized_sector_model_required'
+        END,
+        CASE
+          WHEN diagnostics.market_cap IS NULL OR diagnostics.market_cap <= 0
+            THEN 'missing_market_cap'
+          WHEN diagnostics.market_cap < 50000000
+            THEN 'market_cap_below_50m'
+        END,
+        CASE
+          WHEN diagnostics.average_daily_dollar_volume IS NULL
+            THEN 'missing_average_dollar_volume'
+          WHEN diagnostics.average_daily_dollar_volume < 500000
+            THEN 'average_dollar_volume_below_500k'
+        END,
+        CASE
+          WHEN diagnostics.annual_statement_years < 3
+            THEN 'fewer_than_3_annual_statements'
+        END,
+        CASE
+          WHEN diagnostics.model_class = 'operating'
+            AND diagnostics.positive_fcf_years < 3
+            THEN 'fewer_than_3_positive_fcf_years'
+        END,
+        CASE
+          WHEN diagnostics.latest_annual_date IS NULL
+            OR diagnostics.latest_annual_date < CURRENT_DATE - INTERVAL '21 months'
+            THEN 'annual_statements_stale_or_missing'
+        END,
+        CASE
+          WHEN diagnostics.share_dilution_yoy > 0.50
+            THEN 'share_dilution_over_50pct'
+        END,
+        CASE
+          WHEN diagnostics.ratios_updated_at IS NULL
+            OR diagnostics.ratios_updated_at < pg_catalog.now() - INTERVAL '72 hours'
+            THEN 'ratios_stale_or_missing'
+        END,
+        CASE
+          WHEN diagnostics.profile_updated_at IS NULL
+            OR diagnostics.profile_updated_at < pg_catalog.now() - INTERVAL '72 hours'
+            THEN 'profile_stale_or_missing'
+        END
+      ]::text[], NULL) AS gate_failures,
+      pg_catalog.array_remove(ARRAY[
+        CASE
+          WHEN diagnostics.market_cap >= 50000000
+            AND diagnostics.market_cap < 100000000
+            THEN 'microcap_below_100m'
+        END,
+        CASE
+          WHEN diagnostics.average_daily_dollar_volume >= 500000
+            AND diagnostics.average_daily_dollar_volume < 1000000
+            THEN 'low_liquidity_below_1m_daily'
+        END,
+        CASE WHEN diagnostics.is_adr IS TRUE THEN 'adr' END,
+        CASE WHEN diagnostics.price < 1 THEN 'price_below_1' END,
+        CASE
+          WHEN diagnostics.peg IS NULL OR diagnostics.peg <= 0
+            THEN 'peg_nonpositive_or_missing'
+        END,
+        CASE
+          WHEN diagnostics.price_to_earnings IS NULL
+            OR diagnostics.price_to_earnings <= 0
+            THEN 'pe_nonpositive_or_missing'
+        END,
+        CASE
+          WHEN diagnostics.price_to_free_cash_flow IS NULL
+            OR diagnostics.price_to_free_cash_flow <= 0
+            THEN 'price_to_fcf_nonpositive_or_missing'
+        END,
+        CASE
+          WHEN diagnostics.enterprise_multiple IS NULL
+            OR diagnostics.enterprise_multiple <= 0
+            THEN 'enterprise_multiple_nonpositive_or_missing'
+        END,
+        CASE
+          WHEN diagnostics.share_dilution_yoy > 0.15
+            AND diagnostics.share_dilution_yoy <= 0.50
+            THEN 'share_dilution_over_15pct'
+        END,
+        CASE
+          WHEN diagnostics.accrual_ratio > 0.10
+            THEN 'high_accruals'
+        END,
+        CASE
+          WHEN diagnostics.debt_growth_yoy > 0.50
+            THEN 'debt_growth_over_50pct'
+        END,
+        CASE
+          WHEN diagnostics.revenue_growth_yoy < -0.10
+            THEN 'revenue_decline_over_10pct'
+        END
+      ]::text[], NULL) AS risk_flags
+    FROM raw_diagnostics AS diagnostics
+  )
+  SELECT
+    evaluated.current_rank,
+    evaluated.symbol,
+    evaluated.current_score,
+    evaluated.company_name,
+    evaluated.sector,
+    evaluated.industry,
+    evaluated.exchange,
+    evaluated.market_cap,
+    pg_catalog.round(evaluated.average_daily_dollar_volume, 2),
+    evaluated.annual_statement_years,
+    evaluated.positive_fcf_years,
+    evaluated.latest_annual_date,
+    evaluated.latest_accepted_at,
+    pg_catalog.round(evaluated.revenue_growth_yoy, 4),
+    pg_catalog.round(evaluated.share_dilution_yoy, 4),
+    pg_catalog.round(evaluated.gross_profit_to_assets, 4),
+    pg_catalog.round(evaluated.accrual_ratio, 4),
+    pg_catalog.round(evaluated.free_cash_flow_margin, 4),
+    evaluated.price_to_earnings,
+    evaluated.peg,
+    evaluated.price_to_free_cash_flow,
+    evaluated.enterprise_multiple,
+    evaluated.model_class,
+    pg_catalog.cardinality(evaluated.gate_failures) = 0,
+    evaluated.gate_failures,
+    evaluated.risk_flags
+  FROM evaluated
+  ORDER BY evaluated.current_rank;
+$$;
+
+REVOKE ALL
+ON FUNCTION public.get_compass_quality_shadow_audit(
+  jsonb, integer, text[], text[]
+)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE
+ON FUNCTION public.get_compass_quality_shadow_audit(
+  jsonb, integer, text[], text[]
+)
+TO service_role;
+
+COMMENT ON FUNCTION public.get_compass_quality_shadow_audit(
+  jsonb, integer, text[], text[]
+) IS
+  'Service-only, read-only comparison of current Compass leaders against provisional quality, liquidity, coverage, and security-type gates. It does not alter production ranking.';
+
+COMMIT;

--- a/supabase/tests/compass_quality_shadow_audit.sql
+++ b/supabase/tests/compass_quality_shadow_audit.sql
@@ -1,0 +1,199 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+SET LOCAL statement_timeout = '15s';
+SET LOCAL search_path = public, extensions;
+
+DELETE FROM public.compass_pillar_scores
+WHERE symbol IN ('VFY_QUALITY_GEM', 'VFY_VALUE_TRAP');
+DELETE FROM public.listed_symbols
+WHERE symbol IN ('VFY_QUALITY_GEM', 'VFY_VALUE_TRAP');
+DELETE FROM public.profiles
+WHERE symbol IN ('VFY_QUALITY_GEM', 'VFY_VALUE_TRAP');
+
+INSERT INTO public.profiles (
+  symbol,
+  company_name,
+  price,
+  market_cap,
+  average_volume,
+  exchange,
+  sector,
+  industry,
+  is_etf,
+  is_fund,
+  is_adr
+)
+VALUES
+  (
+    'VFY_QUALITY_GEM', 'Verification Quality Gem', 20, 500000000,
+    200000, 'NASDAQ', 'Technology', 'Software', false, false, false
+  ),
+  (
+    'VFY_VALUE_TRAP', 'Verification Value Trap', 0.5, 10000000,
+    1000, 'NASDAQ', 'Technology', 'Software', false, false, false
+  );
+
+INSERT INTO public.listed_symbols (
+  symbol,
+  is_active,
+  fmp_is_actively_trading
+)
+VALUES
+  ('VFY_QUALITY_GEM', true, true),
+  ('VFY_VALUE_TRAP', true, true);
+
+INSERT INTO public.compass_pillar_scores (
+  symbol, industry, market_cap, revenue_ttm,
+  norm_ps, ps_rank, norm_evm, evm_rank,
+  norm_sentiment, sentiment_rank,
+  norm_profitability_yield, profitability_rank,
+  norm_buyback_yield, buyback_rank,
+  norm_peg, peg_rank, norm_div_yield, div_yield_rank,
+  norm_health, health_rank
+)
+VALUES
+  (
+    'VFY_QUALITY_GEM', 'Software', 500000000, 120000000,
+    90, 1, 90, 1, 90, 1, 90, 1, 90, 1, 90, 1, 90, 1, 90, 1
+  ),
+  (
+    'VFY_VALUE_TRAP', 'Software', 10000000, 80000000,
+    95, 2, 95, 2, 95, 2, 95, 2, 95, 2, 95, 2, 95, 2, 95, 2
+  );
+
+INSERT INTO public.ratios_ttm (
+  symbol,
+  price_to_earnings_ratio_ttm,
+  price_to_earnings_growth_ratio_ttm,
+  price_to_free_cash_flow_ratio_ttm,
+  enterprise_value_multiple_ttm
+)
+VALUES
+  ('VFY_QUALITY_GEM', 12, 1.2, 15, 9),
+  ('VFY_VALUE_TRAP', 0, -3, -1, -2);
+
+INSERT INTO public.financial_statements (
+  symbol,
+  date,
+  period,
+  accepted_date,
+  income_statement_payload,
+  balance_sheet_payload,
+  cash_flow_payload
+)
+VALUES
+  (
+    'VFY_QUALITY_GEM', '2025-12-31', 'FY', '2026-02-15T12:00:00Z',
+    '{"revenue":120000000,"grossProfit":60000000,"netIncome":20000000,"weightedAverageShsOutDil":9500000}',
+    '{"totalAssets":500000000,"totalDebt":80000000}',
+    '{"operatingCashFlow":30000000,"freeCashFlow":25000000}'
+  ),
+  (
+    'VFY_QUALITY_GEM', '2024-12-31', 'FY', '2025-02-15T12:00:00Z',
+    '{"revenue":100000000,"grossProfit":48000000,"netIncome":16000000,"weightedAverageShsOutDil":10000000}',
+    '{"totalAssets":450000000,"totalDebt":90000000}',
+    '{"operatingCashFlow":25000000,"freeCashFlow":20000000}'
+  ),
+  (
+    'VFY_QUALITY_GEM', '2023-12-31', 'FY', '2024-02-15T12:00:00Z',
+    '{"revenue":90000000,"grossProfit":42000000,"netIncome":14000000,"weightedAverageShsOutDil":10200000}',
+    '{"totalAssets":420000000,"totalDebt":95000000}',
+    '{"operatingCashFlow":22000000,"freeCashFlow":18000000}'
+  ),
+  (
+    'VFY_VALUE_TRAP', '2025-12-31', 'FY', '2026-02-15T12:00:00Z',
+    '{"revenue":80000000,"grossProfit":-5000000,"netIncome":-10000000,"weightedAverageShsOutDil":100000000}',
+    '{"totalAssets":10000000,"totalDebt":9000000}',
+    '{"operatingCashFlow":-5000000,"freeCashFlow":-5000000}'
+  ),
+  (
+    'VFY_VALUE_TRAP', '2024-12-31', 'FY', '2025-02-15T12:00:00Z',
+    '{"revenue":100000000,"grossProfit":1000000,"netIncome":-2000000,"weightedAverageShsOutDil":20000000}',
+    '{"totalAssets":12000000,"totalDebt":7000000}',
+    '{"operatingCashFlow":-1000000,"freeCashFlow":-2000000}'
+  ),
+  (
+    'VFY_VALUE_TRAP', '2023-12-31', 'FY', '2024-02-15T12:00:00Z',
+    '{"revenue":105000000,"grossProfit":2000000,"netIncome":1000000,"weightedAverageShsOutDil":18000000}',
+    '{"totalAssets":15000000,"totalDebt":5000000}',
+    '{"operatingCashFlow":2000000,"freeCashFlow":1000000}'
+  );
+
+DO $$
+DECLARE
+  equal_weights CONSTANT jsonb :=
+    '{"revenue":0.125,"value":0.125,"sentiment":0.125,"growth":0.125,"profitability":0.125,"buyback":0.125,"income":0.125,"health":0.125}'::jsonb;
+  gem record;
+  trap record;
+BEGIN
+  SELECT * INTO gem
+  FROM public.get_compass_quality_shadow_audit(
+    equal_weights, 50, ARRAY['Software'], NULL
+  )
+  WHERE symbol = 'VFY_QUALITY_GEM';
+
+  SELECT * INTO trap
+  FROM public.get_compass_quality_shadow_audit(
+    equal_weights, 50, ARRAY['Software'], NULL
+  )
+  WHERE symbol = 'VFY_VALUE_TRAP';
+
+  IF gem.symbol IS NULL OR NOT gem.passes_provisional_gate THEN
+    RAISE EXCEPTION 'Quality-gem fixture should pass: %', gem;
+  END IF;
+
+  IF gem.positive_fcf_years <> 3
+     OR gem.share_dilution_yoy IS DISTINCT FROM -0.0500::numeric
+     OR gem.revenue_growth_yoy IS DISTINCT FROM 0.2000::numeric THEN
+    RAISE EXCEPTION 'Quality-gem diagnostics mismatch: %', gem;
+  END IF;
+
+  IF trap.symbol IS NULL OR trap.passes_provisional_gate THEN
+    RAISE EXCEPTION 'Value-trap fixture should fail: %', trap;
+  END IF;
+
+  IF NOT trap.gate_failures @> ARRAY[
+    'market_cap_below_50m',
+    'average_dollar_volume_below_500k',
+    'fewer_than_3_positive_fcf_years',
+    'share_dilution_over_50pct'
+  ]::text[] THEN
+    RAISE EXCEPTION 'Expected value-trap failures are missing: %', trap.gate_failures;
+  END IF;
+
+  IF NOT trap.risk_flags @> ARRAY[
+    'peg_nonpositive_or_missing',
+    'pe_nonpositive_or_missing',
+    'price_to_fcf_nonpositive_or_missing',
+    'enterprise_multiple_nonpositive_or_missing',
+    'revenue_decline_over_10pct'
+  ]::text[] THEN
+    RAISE EXCEPTION 'Expected value-trap warnings are missing: %', trap.risk_flags;
+  END IF;
+
+  IF pg_catalog.has_function_privilege(
+    'anon',
+    'public.get_compass_quality_shadow_audit(jsonb,integer,text[],text[])',
+    'EXECUTE'
+  ) OR pg_catalog.has_function_privilege(
+    'authenticated',
+    'public.get_compass_quality_shadow_audit(jsonb,integer,text[],text[])',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'Shadow audit must remain inaccessible to client roles';
+  END IF;
+
+  IF NOT pg_catalog.has_function_privilege(
+    'service_role',
+    'public.get_compass_quality_shadow_audit(jsonb,integer,text[],text[])',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'Service role cannot execute shadow audit';
+  END IF;
+END;
+$$;
+
+ROLLBACK;
+
+\echo 'compass_quality_shadow_audit: PASS'

--- a/tests/contracts/README.md
+++ b/tests/contracts/README.md
@@ -73,6 +73,7 @@ ROLLBACK;
 - ✅ **Contract #16:** Polite partition maintenance (`maintain_queue_partitions_v2`)
 - ✅ **Contract #17:** Deadlock-aware error handling (processor)
 - ✅ **Contract #18:** `SECURITY DEFINER` on `check_and_queue_stale_batch_v2`
+- ✅ **Contract #23:** Compass quality shadow audit remains read-only and service-only
 
 ### TypeScript Contracts (ESLint Rules)
 

--- a/tests/contracts/test_contract_23_compass_quality_shadow_audit.sql
+++ b/tests/contracts/test_contract_23_compass_quality_shadow_audit.sql
@@ -1,0 +1,69 @@
+-- Contract #23: Compass quality audit is read-only and service-only.
+
+BEGIN;
+SELECT plan(4);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc AS procedure
+    JOIN pg_namespace AS namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname = 'public'
+      AND procedure.proname = 'get_compass_quality_shadow_audit'
+      AND procedure.provolatile = 's'
+      AND NOT procedure.prosecdef
+  ),
+  'Contract #23: shadow audit exists, is stable, and uses caller permissions'
+);
+
+SELECT ok(
+  has_function_privilege(
+    'service_role',
+    'public.get_compass_quality_shadow_audit(jsonb,integer,text[],text[])',
+    'EXECUTE'
+  )
+  AND NOT has_function_privilege(
+    'anon',
+    'public.get_compass_quality_shadow_audit(jsonb,integer,text[],text[])',
+    'EXECUTE'
+  )
+  AND NOT has_function_privilege(
+    'authenticated',
+    'public.get_compass_quality_shadow_audit(jsonb,integer,text[],text[])',
+    'EXECUTE'
+  ),
+  'Contract #23: only service code can execute the shadow audit'
+);
+
+SELECT ok(
+  position(
+    'api_call_queue_v2'
+    IN pg_get_functiondef(
+      'public.get_compass_quality_shadow_audit(jsonb,integer,text[],text[])'::regprocedure
+    )
+  ) = 0
+  AND position(
+    'http_'
+    IN pg_get_functiondef(
+      'public.get_compass_quality_shadow_audit(jsonb,integer,text[],text[])'::regprocedure
+    )
+  ) = 0,
+  'Contract #23: shadow audit neither queues work nor invokes HTTP'
+);
+
+SELECT ok(
+  pg_get_function_result(
+    'public.get_compass_quality_shadow_audit(jsonb,integer,text[],text[])'::regprocedure
+  ) LIKE '%passes_provisional_gate boolean%'
+  AND pg_get_function_result(
+    'public.get_compass_quality_shadow_audit(jsonb,integer,text[],text[])'::regprocedure
+  ) LIKE '%gate_failures text[]%'
+  AND pg_get_function_result(
+    'public.get_compass_quality_shadow_audit(jsonb,integer,text[],text[])'::regprocedure
+  ) LIKE '%risk_flags text[]%',
+  'Contract #23: shadow audit reports pass/fail reasons without changing rank'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Adds a service-only shadow audit for Compass recommendations. It identifies value traps, invalid valuation ratios, insufficient financial history, poor liquidity, severe dilution, stale data, and companies requiring sector-specific models.
This does not change production rankings and makes zero FMP calls.
Validation: full migration replay, financial fixtures, ranking verification, 104 database contracts, Playwright 8/8, and production build all passed.